### PR TITLE
updated dataset preparation to work

### DIFF
--- a/credoai/modules/credo_module.py
+++ b/credoai/modules/credo_module.py
@@ -27,11 +27,13 @@ class CredoModule(ABC):
         Returns
         --------
         pd.DataFrame or pd.Series or dict
-            if pd.DataFrame, the index should be
-            called "metric" and list the metric,
-            and the first column should be called
-            "value" which contains the metrics value 
-            as a single number
+            if pd.DataFrame, the index must be "metric_type", with one column called
+            "value", which contains the metrics value as a single number. Other columns
+            may be included as metadata.
+
+            If a series, the single column should include the "value" column.
+
+            If a dictionary, the key/val pairs should be metric_type/value
         """
         if self.results is not None:
             # prepare results code

--- a/credoai/modules/dataset_modules/dataset_base.py
+++ b/credoai/modules/dataset_modules/dataset_base.py
@@ -75,8 +75,45 @@ class DatasetModule(CredoModule):
         return self  
     
     def prepare_results(self):
+        """Prepares results for export to Credo AI's governance platform
+
+        Structures a subset of results for export as a dataframe with appropriate structure
+        for exporting. See credoai.modules.credo_module.
+
+        Returns
+        -------
+        pd.DataFrame
+
+        Raises
+        ------
+        NotRunError
+            If results have not been run, raise
+        """
         if self.results is not None:
-            return self.results
+            metric_types = ['sensitive_feature_prediction_score',
+           'demographic_parity_difference',
+           'demographic_parity_ratio']
+            index = []
+            prepared_arr = []
+            for metric_type in metric_types:
+                val = self.results[metric_type]
+                # if multiple values were calculated for metric_type
+                # add them all. Assumes each element of list is a dictionary with a "value" key,
+                # and other optional keys as metricmetadata
+                if isinstance(val, list):
+                    for l in val:
+                        index.append(metric_type)
+                        prepared_arr.append(l)
+                else:
+                    # assumes the dictionary has a "value" key, along with other optional keys
+                    # as metric metadata
+                    if isinstance(val, dict):
+                        tmp = val
+                    elif isinstance(val, (int, float)):
+                        tmp = {'value': val}
+                    index.append(metric_type)
+                    prepared_arr.append(tmp)
+            return pd.DataFrame(prepared_arr, index=index).rename_axis(index='metric_type')
         else:
             raise NotRunError(
                 "Results not created yet. Call 'run' to create results"

--- a/credoai/modules/model_modules/fairness_base.py
+++ b/credoai/modules/model_modules/fairness_base.py
@@ -94,6 +94,9 @@ class FairnessModule(CredoModule):
     def prepare_results(self, method='between_groups', filter=None):
         """prepares fairness and disaggregated results to Credo AI
 
+        Structures results for export as a dataframe with appropriate structure
+        for exporting. See credoai.modules.credo_module.
+
         Parameters
         ----------
         method : str, optional  


### PR DESCRIPTION
## Change description

Updated dataset to return "prepared_results". Implicitly started creating "dataset metric types", which will be rolled into the overall taxonomy of metrics. Prepared results look like this:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/85892367/157294799-129aa109-9c3f-4fc7-ad26-719d1cdfa3a2.png">

Notice the metadata associated with individual metrics. "target" is associated with some, but not others. I think the "target" is confusing currently. We don't have an equivalent idea for the fairness base module. But I think it's fine to not deal for now
