### PR TITLE
Fix async notebook execution by using reentrant asyncio

### DIFF
--- a/credoai/reporting/reports.py
+++ b/credoai/reporting/reports.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from inspect import cleandoc
 from nbclient import NotebookClient
 from jupyterlab_nbconvert_nocode.nbconvert_functions import HTMLHideCodeExporter
+import asyncio
+import nest_asyncio
 
 class NotebookReport():
     def __init__(self):
@@ -62,8 +64,9 @@ class NotebookReport():
     def run_notebook(self):
         client = NotebookClient(self.nb, timeout=600, 
                     kernel_name='python3')
-
-        client.execute()
+        loop = asyncio.new_event_loop()
+        nest_asyncio.apply(loop)
+        loop.run_until_complete(client.async_execute())
         return self
 
     def _preprocess_cell_content(self, cells):
@@ -101,8 +104,9 @@ class AssessmentReport(NotebookReport):
             pickle.dump(val, open(pickle_files[-1], 'wb'))
         client = NotebookClient(self.nb, timeout=600, 
                     kernel_name='python3')
-
-        client.execute()
+        loop = asyncio.new_event_loop()
+        nest_asyncio.apply(loop)
+        loop.run_until_complete(client.async_execute())
         for f in pickle_files:
             os.remove(f)
         return self

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ set_type_checking_flag = True  # Enable 'expensive' imports for sphinx_autodoc_t
 nbsphinx_allow_errors = True  # Continue through Jupyter errors
 nbsphinx_execute = 'never'
 autodoc_mock_imports = [
+    'nest_asyncio',
     'absl',
     'dotenv', 
     'fairlearn',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+nest_asyncio>=1.5.4
 absl-py>=1.0.0
 fairlearn>=0.7.0
 json-api-doc>=0.15.0


### PR DESCRIPTION
## Change description

Using Quickstart notebook, Restart & Run all causes below error then kernel dies. Root cause is non-rentrant default asyncio, which can be fixed by applying the nest_asyncio library.
Background: https://bugs.python.org/issue22239

Traceback (most recent call last):
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/site-packages/ipykernel_launcher.py", line 16, in <module>
    app.launch_new_instance()
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/site-packages/traitlets/config/application.py", line 846, in launch_instance
    app.start()
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/site-packages/ipykernel/kernelapp.py", line 677, in start
    self.io_loop.start()
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/site-packages/tornado/platform/asyncio.py", line 199, in start
    self.asyncio_loop.run_forever()
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
  File "/Users/eli/miniconda3/envs/dogfood/lib/python3.9/asyncio/base_events.py", line 1875, in _run_once
    handle = self._ready.popleft()
IndexError: pop from an empty deque


## Type of change
- [ x ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
