### PR TITLE
Feat/labels

### DIFF
--- a/credoai/integration.py
+++ b/credoai/integration.py
@@ -63,7 +63,8 @@ class Metric(Record):
         String reflecting the process used to create the metric. E.g.,
         name of a particular Lens assessment, or link to code.
     metadata : dict, optional
-        Arbitrary keyword arguments to append to metric as metadata
+        Arbitrary keyword arguments to append to metric as metadata. These will be
+        displayed in the governance app
 
     Example
     ---------
@@ -94,7 +95,7 @@ class Metric(Record):
             'value': self.value,
             'dataset_id': self.dataset_id,
             'process': self.process,
-            'metadata': self.metadata,
+            'labels': self.metadata,
             'value_updated_at': self.creation_time,
         }
 

--- a/credoai/lens.py
+++ b/credoai/lens.py
@@ -331,7 +331,7 @@ class Lens:
                     assessment.init_module(**kwargs)
                 except:
                     raise ValidationError(f"Assessment ({assessment.get_name()}) could not be initialized."
-                                          "Ensure the assessment spec is passing the required parameters"
+                                          " Ensure the assessment spec is passing the required parameters"
                                           )
 
     def _prepare_results(self, assessment, **kwargs):

--- a/credoai/lens.py
+++ b/credoai/lens.py
@@ -294,13 +294,8 @@ class Lens:
             dataset_id = self.gov.dataset_id
         elif assessment.data_name == self.training_dataset.name:
             dataset_id = self.gov.training_dataset_id
-        return {'process': f'Lens-{assessment.name}',
-                'model_label': assessment.model_name,
-                'dataset_label': assessment.data_name,
-                'dataset_id': dataset_id,
-                'user_id': self.user_id,
-                'assessment': assessment.name,
-                'lens_version': f'Lens-v{__version__}'}
+        return {'process': f'Lens-v{__version__}_{assessment.name}',
+                'dataset_id': dataset_id}
 
     def _get_credo_destination(self, to_model=True):
         """Get destination for export and ensure all artifacts are registered"""


### PR DESCRIPTION
## Change description

This PR adds labels for display. A difficulty I encountered was separating the arbitrary metadata meant for display from the arbitrary metadata meant to ... just exist. Rather than deal with this complexity, it seems that the arbitrary "exist" metadata was serving no purpose.

I ensured that we have all the information we need when sending the metrics. User ID and model ID can be inferred from the API token and where the assessments were sent. Names can obviously be inferred from the IDs. I combined assessment and lens version into "process",

beyond those "expected metadata" pieces, the rest will be added to labels.