### PR TITLE
Added percentage labels to data balance plot

### DIFF
--- a/credoai/lens.py
+++ b/credoai/lens.py
@@ -267,6 +267,7 @@ class Lens:
                 continue
             reporter.display_results_tables()
             reporter.plot_results()
+        return self
 
     def _apply_dev_mode(self, dev_mode):
         if dev_mode:

--- a/credoai/reporting/dataset_fairness.py
+++ b/credoai/reporting/dataset_fairness.py
@@ -131,15 +131,7 @@ class DatasetFairnessReporter(CredoReporter):
                 palette=plot_utils.credo_diverging_palette(1),
                 ax=axes[0],
             )
-            percentages = []
-            for c in ax.containers[0]:
-                percentages.append(100 * c.get_width() / df['count'].sum())
-            percentages = [f'{i:.1f}%' for i in percentages]
-            ax.bar_label(
-                ax.containers[0],
-                labels=percentages,
-                color=plot_utils.credo_diverging_palette(1)[0]
-            )
+            self._add_bar_percentages(ax)
 
             f.patch.set_facecolor("white")
             sns.despine()
@@ -163,6 +155,7 @@ class DatasetFairnessReporter(CredoReporter):
                     alpha=1,
                     ax=axes[1],
                 )
+                self._add_bar_percentages(ax)
                 f.patch.set_facecolor("white")
                 sns.despine()
                 ax.set_title(
@@ -193,6 +186,7 @@ class DatasetFairnessReporter(CredoReporter):
                     palette=plot_utils.credo_diverging_palette(num_classes),
                     ax=axes[2],
                 )
+                self._add_bar_percentages(ax)
                 f.patch.set_facecolor("white")
                 sns.despine()
                 plt.title("Parity metrics for different preferred label value possibilities")
@@ -367,4 +361,29 @@ class DatasetFairnessReporter(CredoReporter):
             ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
             ax.legend(loc='upper right')
         self.figs.append(f)
+
+    def _add_bar_percentages(self, ax):
+        bar_groups = list(zip(*ax.containers))
+        totals = [sum([c.get_width() for c in containers]) for containers in bar_groups]
+            
+        for containers in ax.containers:
+            widths = [c.get_width() for c in containers]
+            percentages = [100*w/totals[i] for i,w in enumerate(widths)]
+            percentage_text = [f'{i:.1f}%' for i in percentages]
+            if min(percentages) > 10:
+                ax.bar_label(
+                    containers,
+                    labels=percentage_text,
+                    color='white',
+                    label_type='center'
+                )
+            else:
+                ax.bar_label(
+                        containers,
+                        labels=percentage_text,
+                        color=plot_utils.credo_diverging_palette(1)[0],
+                        padding=2
+                    )
+
+
 

--- a/credoai/reporting/dataset_fairness.py
+++ b/credoai/reporting/dataset_fairness.py
@@ -131,7 +131,7 @@ class DatasetFairnessReporter(CredoReporter):
                 palette=plot_utils.credo_diverging_palette(1),
                 ax=axes[0],
             )
-            self._add_bar_percentages(ax)
+            self._add_bar_percentages(ax, self.size*1.5)
 
             f.patch.set_facecolor("white")
             sns.despine()
@@ -155,7 +155,7 @@ class DatasetFairnessReporter(CredoReporter):
                     alpha=1,
                     ax=axes[1],
                 )
-                self._add_bar_percentages(ax)
+                self._add_bar_percentages(ax, self.size*1.5)
                 f.patch.set_facecolor("white")
                 sns.despine()
                 ax.set_title(
@@ -186,7 +186,6 @@ class DatasetFairnessReporter(CredoReporter):
                     palette=plot_utils.credo_diverging_palette(num_classes),
                     ax=axes[2],
                 )
-                self._add_bar_percentages(ax)
                 f.patch.set_facecolor("white")
                 sns.despine()
                 plt.title("Parity metrics for different preferred label value possibilities")
@@ -362,28 +361,34 @@ class DatasetFairnessReporter(CredoReporter):
             ax.legend(loc='upper right')
         self.figs.append(f)
 
-    def _add_bar_percentages(self, ax):
+    def _add_bar_percentages(self, ax, fontsize=10):
+        n_containers = len(ax.containers)
         bar_groups = list(zip(*ax.containers))
         totals = [sum([c.get_width() for c in containers]) for containers in bar_groups]
-            
+        overall_total = sum(totals)
+        if n_containers == 1:
+            totals = [overall_total for i in totals]
         for containers in ax.containers:
             widths = [c.get_width() for c in containers]
             percentages = [100*w/totals[i] for i,w in enumerate(widths)]
+            overall_percentages = [100*w/overall_total for i,w in enumerate(widths)]
             percentage_text = [f'{i:.1f}%' for i in percentages]
-            if min(percentages) > 10:
+            if min(overall_percentages) > 10:
                 ax.bar_label(
                     containers,
                     labels=percentage_text,
                     color='white',
-                    label_type='center'
+                    label_type='center',
+                    fontsize=fontsize/n_containers
                 )
             else:
                 ax.bar_label(
-                        containers,
-                        labels=percentage_text,
-                        color=plot_utils.credo_diverging_palette(1)[0],
-                        padding=2
-                    )
+                    containers,
+                    labels=percentage_text,
+                    color=plot_utils.credo_diverging_palette(1)[0],
+                    padding=2,
+                    fontsize=fontsize/n_containers
+                )
 
 
 

--- a/credoai/reporting/dataset_fairness.py
+++ b/credoai/reporting/dataset_fairness.py
@@ -1,3 +1,4 @@
+from turtle import color
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mtick
 import pandas as pd
@@ -130,6 +131,16 @@ class DatasetFairnessReporter(CredoReporter):
                 palette=plot_utils.credo_diverging_palette(1),
                 ax=axes[0],
             )
+            percentages = []
+            for c in ax.containers[0]:
+                percentages.append(100 * c.get_width() / df['count'].sum())
+            percentages = [f'{i:.1f}%' for i in percentages]
+            ax.bar_label(
+                ax.containers[0],
+                labels=percentages,
+                color=plot_utils.credo_diverging_palette(1)[0]
+            )
+
             f.patch.set_facecolor("white")
             sns.despine()
             ax.set_title("Data balance across " + sensitive_feature_name + " subgroups")


### PR DESCRIPTION
A small PR that add percentage labels to data balance plot.
Runningun [dataset_assessment.ipynb](https://github.com/credo-ai/credoai_lens/blob/develop/docs/notebooks/lens_demos/dataset_assessment.ipynb):

![image](https://user-images.githubusercontent.com/92744575/165542407-c78e1bca-75f8-48d3-9ab8-e2c0bc2627f4.png)
![image](https://user-images.githubusercontent.com/92744575/165542586-5f3276bd-d4c4-4d53-b18f-c79c9261843a.png)

