### PR TITLE
Metric search exception handling

### DIFF
--- a/credoai/modules/model_modules/fairness_base.py
+++ b/credoai/modules/model_modules/fairness_base.py
@@ -206,9 +206,9 @@ class FairnessModule(PerformanceModule):
                 if len(metric) == 1:
                     metric = metric[0]
                 elif len(metric) == 0:
-                    raise Exception("Returned no metrics when searching using a metric name. Expected to find one matching metric.")
+                    raise Exception(f"Returned no metrics when searching using the provided metric name <{metric_name}>. Expected to find one matching metric.")
                 else:
-                    raise Exception("Returned multiple metrics when searching using a metric name. Expected to find only one matching metric.")
+                    raise Exception(f"Returned multiple metrics when searching using the provided metric name <{metric_name}>. Expected to find only one matching metric.")
             else:
                 metric_name = metric.name
             if not isinstance(metric, Metric):

--- a/credoai/modules/model_modules/performance_base.py
+++ b/credoai/modules/model_modules/performance_base.py
@@ -218,8 +218,10 @@ class PerformanceModule(CredoModule):
                 metric = find_metrics(metric, MODEL_METRIC_CATEGORIES)
                 if len(metric) == 1:
                     metric = metric[0]
+                elif len(metric) == 0:
+                    raise Exception(f"Returned no metrics when searching using the provided metric name <{metric_name}>. Expected to find one matching metric.")
                 else:
-                    raise Exception("Returned multiple metrics when searching using a metric name. Expected to find only one matching metric")
+                    raise Exception(f"Returned multiple metrics when searching using the provided metric name <{metric_name}>. Expected to find only one matching metric.")
             else:
                 metric_name = metric.name
             if not isinstance(metric, Metric):


### PR DESCRIPTION
This small PR addresses cases where Lens does not find any matches for a user-specified metric name.