### PR TITLE
moved over from IDs to names

### DIFF
--- a/credoai/artifacts.py
+++ b/credoai/artifacts.py
@@ -74,15 +74,20 @@ class CredoGovernance:
                  dataset_name: str = None,
                  training_dataset_name: str = None,
                  warning_level=1):
+        self.use_case_id = None
+        self.model_id = None
+        self.dataset_id = None
+        self.training_dataset_id = None
+
+        # set up names and retrieve ids
         self.use_case_name = use_case_name
         self.model_name = model_name
         self.dataset_name = dataset_name
         self.training_dataset_name = training_dataset_name
-        self._set_governance_info_by_name(use_case_name=use_case_name)
-
-        self.model_id = None
-        self.dataset_id = None
-        self.training_dataset_id = None
+        self._set_governance_info_by_name(use_case_name=self.use_case_name,
+                                          model_name=self.model_name,
+                                          dataset_name=self.dataset_name,
+                                          training_dataset_name=self.training_dataset_name)
         self.assessment_spec = {}
         self.warning_level = warning_level
 

--- a/credoai/integration.py
+++ b/credoai/integration.py
@@ -58,8 +58,8 @@ class Metric(Record):
         metric value
     subtype : string, optional
         subtype of metric. Defaults to base
-    dataset_id : str, optional
-        ID of dataset. Should match a dataset on Governance App
+    dataset_name : str, optional
+        Name of dataset. Should match a dataset on Governance App
     process : string, optional
         String reflecting the process used to create the metric. E.g.,
         name of a particular Lens assessment, or link to code.
@@ -76,14 +76,14 @@ class Metric(Record):
                  metric_type,
                  value,
                  subtype="base",
-                 dataset_id=None,
+                 dataset_name=None,
                  process=None,
                  **metadata):
         super().__init__('metrics', **metadata)
         self.metric_type = metric_type
         self.value = value
         self.subtype = subtype
-        self.dataset_id = dataset_id
+        self.dataset_name = dataset_name
         self.process = process
         self.config_hash = self._generate_config()
 
@@ -94,7 +94,7 @@ class Metric(Record):
             'type': self.metric_type,
             'subtype': self.subtype,
             'value': self.value,
-            'dataset_id': self.dataset_id,
+            'dataset_name': self.dataset_name,
             'process': self.process,
             'labels': self.metadata,
             'value_updated_at': self.creation_time,

--- a/credoai/lens.py
+++ b/credoai/lens.py
@@ -109,7 +109,7 @@ class Lens:
             else:
                 self.gov = governance
         else:
-            self.gov = CredoGovernance(warning_level=warning_level)
+            self.gov = CredoGovernance(use_case_name=None, warning_level=warning_level)
 
         # set up assessments
         self.assessments = self._select_assessments(assessments)

--- a/docs/notebooks/governance_integration.ipynb
+++ b/docs/notebooks/governance_integration.ipynb
@@ -37,18 +37,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ddde09b9-b132-4e8f-a411-395876b6389d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<frozen importlib._bootstrap>:228: RuntimeWarning: scipy._lib.messagestream.MessageStream size changed, may indicate binary incompatibility. Expected 56 from C header, got 64 from PyObject\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# model and df are defined by this script\n",
     "%run training_script.py"
@@ -64,19 +56,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "fec8ade6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/homebrew/Caskroom/miniforge/base/envs/conda_dev/lib/python3.9/site-packages/numba/cpython/hashing.py:484: UserWarning: FNV hashing is not implemented in Numba. See PEP 456 https://www.python.org/dev/peps/pep-0456/ for rationale over not using FNV. Numba will continue to work, but hashes for built in types will be computed using siphash24. This will permit e.g. dictionaries to continue to behave as expected, however anything relying on the value of the hash opposed to hash as a derived property is likely to not work as expected.\n",
-      "  warnings.warn(msg)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Base Lens imports\n",
     "import credoai.lens as cl\n",
@@ -98,62 +81,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "56a2c936-e8a6-4232-b33f-a7f2995cbbf3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:absl:Automatically Selected Assessments for Model without data\n",
-      "\n",
-      "INFO:absl:Automatically Selected Assessments for model: credit_default_classifier and validation dataset: UCI-credit-default\n",
-      "--\n",
-      "INFO:absl:Selected assessments...\n",
-      "--DatasetFairness\n",
-      "--DatasetProfiling\n",
-      "--Fairness\n",
-      "--Performance\n",
-      "INFO:absl:Initializing assessments for validation dataset: UCI-credit-default\n",
-      "INFO:absl:fairness metric, equal_opportunity, unused by PerformanceModule\n",
-      "INFO:absl:Running assessment-DatasetFairness\n",
-      "INFO:absl:Running assessment-DatasetProfiling\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4d685fa8bf1b49c8afca47b3ad2799ab",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Summarize dataset:   0%|          | 0/5 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:absl:Running assessment-Fairness\n",
-      "INFO:absl:Running assessment-Performance\n",
-      "WARNING:absl:The model (credit_default_classifier) is already registered. Using registered model\n",
-      "INFO:absl:Registering model (credit_default_classifier) to Use Case (VhST9gvC3CWVpWtQKp4wL3)\n",
-      "WARNING:absl:The dataset (UCI-credit-default) is already registered. Using registered dataset\n",
-      "INFO:absl:Registering dataset (UCI-credit-default) as validation data for model (credit_default_classifier) for use case (al use case1)\n",
-      "INFO:absl:** Exporting assessment-DatasetFairness\n",
-      "INFO:absl:** Exporting assessment-DatasetProfiling\n",
-      "INFO:absl:** Exporting assessment-Fairness\n",
-      "INFO:absl:** Exporting assessment-Performance\n",
-      "WARNING:absl:No report is included. To include a report, run create_reports first\n",
-      "INFO:absl:Exporting assessments to Credo AI's Governance App\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "credo_model = cl.CredoModel(name='credit_default_classifier',\n",
     "                            model=model)\n",

--- a/docs/notebooks/governance_integration.ipynb
+++ b/docs/notebooks/governance_integration.ipynb
@@ -37,10 +37,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ddde09b9-b132-4e8f-a411-395876b6389d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<frozen importlib._bootstrap>:228: RuntimeWarning: scipy._lib.messagestream.MessageStream size changed, may indicate binary incompatibility. Expected 56 from C header, got 64 from PyObject\n"
+     ]
+    }
+   ],
    "source": [
     "# model and df are defined by this script\n",
     "%run training_script.py"
@@ -56,10 +64,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "fec8ade6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/homebrew/Caskroom/miniforge/base/envs/conda_dev/lib/python3.9/site-packages/numba/cpython/hashing.py:484: UserWarning: FNV hashing is not implemented in Numba. See PEP 456 https://www.python.org/dev/peps/pep-0456/ for rationale over not using FNV. Numba will continue to work, but hashes for built in types will be computed using siphash24. This will permit e.g. dictionaries to continue to behave as expected, however anything relying on the value of the hash opposed to hash as a derived property is likely to not work as expected.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    }
+   ],
    "source": [
     "# Base Lens imports\n",
     "import credoai.lens as cl\n",
@@ -81,10 +98,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "56a2c936-e8a6-4232-b33f-a7f2995cbbf3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:absl:Automatically Selected Assessments for Model without data\n",
+      "\n",
+      "INFO:absl:Automatically Selected Assessments for model: credit_default_classifier and validation dataset: UCI-credit-default\n",
+      "--\n",
+      "INFO:absl:Selected assessments...\n",
+      "--DatasetFairness\n",
+      "--DatasetProfiling\n",
+      "--Fairness\n",
+      "--Performance\n",
+      "INFO:absl:Initializing assessments for validation dataset: UCI-credit-default\n",
+      "INFO:absl:fairness metric, equal_opportunity, unused by PerformanceModule\n",
+      "INFO:absl:Running assessment-DatasetFairness\n",
+      "INFO:absl:Running assessment-DatasetProfiling\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4d685fa8bf1b49c8afca47b3ad2799ab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Summarize dataset:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:absl:Running assessment-Fairness\n",
+      "INFO:absl:Running assessment-Performance\n",
+      "WARNING:absl:The model (credit_default_classifier) is already registered. Using registered model\n",
+      "INFO:absl:Registering model (credit_default_classifier) to Use Case (VhST9gvC3CWVpWtQKp4wL3)\n",
+      "WARNING:absl:The dataset (UCI-credit-default) is already registered. Using registered dataset\n",
+      "INFO:absl:Registering dataset (UCI-credit-default) as validation data for model (credit_default_classifier) for use case (al use case1)\n",
+      "INFO:absl:** Exporting assessment-DatasetFairness\n",
+      "INFO:absl:** Exporting assessment-DatasetProfiling\n",
+      "INFO:absl:** Exporting assessment-Fairness\n",
+      "INFO:absl:** Exporting assessment-Performance\n",
+      "WARNING:absl:No report is included. To include a report, run create_reports first\n",
+      "INFO:absl:Exporting assessments to Credo AI's Governance App\n"
+     ]
+    }
+   ],
    "source": [
     "credo_model = cl.CredoModel(name='credit_default_classifier',\n",
     "                            model=model)\n",
@@ -103,7 +172,7 @@
     "lens = cl.Lens(model=credo_model,\n",
     "               data=credo_data,\n",
     "               spec=alignment_spec,\n",
-    "               governance='use-case-id' # <- NEW LINE!\n",
+    "               governance='use-case-name' # <- NEW LINE!\n",
     "               )\n",
     "\n",
     "lens.run_assessments().create_report().export() # <- Added export!"
@@ -116,7 +185,7 @@
    "source": [
     "Those two lines did a number of things under the hood.\n",
     "\n",
-    "* First a [CredoGovernance Artifact](#Credo-Governance-Artifact) was created with the use_case_id set to the provided use_case_id.\n",
+    "* First a [CredoGovernance Artifact](#Credo-Governance-Artifact) was created with the use_case_name set to the provided use case's name.\n",
     "* Next the model and datasets were registered:\n",
     "    * The model was registered to the Governance App\n",
     "    * The model was registered to the specific use-case associated with the id\n",
@@ -135,21 +204,16 @@
     "\n",
     "### Credo Governance Artifact\n",
     "\n",
-    "Lens connects to the Governance App via a `CredoGovernance` object. This specifies the IDs of the Use Case, model and data you want to associate your assessments with. The IDs are found in the url of your Use Case or model.\n",
-    "\n",
-    "For instance, the Use Case ID is found here: `...credo.com/use-cases/{use_case_id}`\n",
-    "\n",
-    "And the model Id is found here: `...credo.com/models/{model_id}`\n",
+    "Lens connects to the Governance App via a `CredoGovernance` object. This uses the names of the Use Case, model and data you want to associate your assessments with. \n",
     "\n",
     "The CredoGovernance object has a few functionalities.\n",
     "\n",
-    "* Retrieving an alignment spec from the Use Case for a specific model ID (created during the aligned process). The alignment spec is either downloaded straight from the Governance App, or supplied as a json file for air gap deployment. This alignment spec can be supplemented (or overwritten) with an alignment spec you define in code and pass to Lens.\n",
-    "* Registering artifacts (models, datasets) to the Governance App.\n",
-    "* Encoding the IDs of governance objects so Lens can easily export metrics and reports.\n",
+    "* Retrieving an alignment spec from the Use Case for a specific model (created during the aligned process). The alignment spec is either downloaded straight from the Governance App, or supplied as a json file for air gap deployment. This alignment spec can be supplemented (or overwritten) with an alignment spec you define in code and pass to Lens.\n",
+    "* Connecting Lens with the Use Case, model and dataset on the governance app to support easy exporting of metrics and reports.\n",
     "\n",
     "\\** **Attention** \\**\n",
     "\n",
-    "The metrics and reports will _either_ be exported to the model and data specified in by `CredoGovernance` (using the `model_id` and `data_id` arguments) OR a new model and data will be registered on your CredoGovernance app automatically, which will then be used for export. You can also set the ids using the model/dataset _name_ by calling `credo_gov.set_governance_info_by_name`.\n",
+    "The metrics and reports will _either_ be exported to the model and data specified in by `CredoGovernance` (e.g., using the `model_name`) OR a new model and data will be registered on your CredoGovernance app automatically, which will then be used for export. \n",
     "\n",
     "With that said, let's see how this works in practice."
    ]
@@ -162,12 +226,7 @@
    "outputs": [],
    "source": [
     "# New artifact for governance\n",
-    "# Because a model id is provided, the model will not be\n",
-    "# registered and assessments will be exported to the existing\n",
-    "# \"your-model_id\"\n",
-    "credo_gov = cl.CredoGovernance(use_case_id=\"your-use-case-id\",\n",
-    "                               model_id=\"your-model-id\"\n",
-    "                               )\n",
+    "credo_gov = cl.CredoGovernance(use_case_name=\"your-use-case-name\")\n",
     "\n",
     "credo_model = cl.CredoModel(name='credit_default_classifier',\n",
     "                            model=model)\n",
@@ -195,7 +254,7 @@
     "\n",
     "In addition to the model and data, we can pass the CredoGovernance object. This is how Lens knows which Use Case, model and/or data to interacts with. If you are running assessments on multiple models, you'll create a separate `CredoGovernance` object (and separate Lens instances) for each.\n",
     "\n",
-    "You can also pass the `use-case ID` and nothing else. In this case a CredoGovernance object will be created and the model/dataset names will be used for registration and exporting."
+    "You can also pass the `use case name` and nothing else. In this case a CredoGovernance object will be created and the model/dataset names will be used for registration and exporting."
    ]
   },
   {
@@ -252,7 +311,7 @@
     "\n",
     "You may not have a model or dataset registered yet in the Governance App to receive your assessments.  If you still want to log a model assessment, Lens will take care of registering a new model on Credo AI's Governance App first. \n",
     "\n",
-    "You still need to provide a use-case ID however. You can do this by creating a `CredoGovernance` object, or just by supplying the use-case ID to the \"governance\" argument, as we do below.\n",
+    "You still need to provide a use-case name however. You can do this by creating a `CredoGovernance` object, or just by supplying the use-case name to the \"governance\" argument, as we do below.\n",
     "\n",
     "The below will create a project called `an example model project` and log the model `an example model ` under it."
    ]
@@ -272,7 +331,7 @@
     "               assessments = [FairnessAssessment],\n",
     "               data=credo_data,\n",
     "               spec=alignment_spec,\n",
-    "               governance='use-case-id')\n",
+    "               governance='use-case-name')\n",
     "\n",
     "# Note! The below won't export anything unless you supply a use-case id\n",
     "# A warning will be raised to inform you of this.\n",
@@ -306,7 +365,7 @@
     "\\** **Attention** \\**\n",
     "\n",
     "\n",
-    "Note that if you run the above a second time, the model doesn't have to be registered again - it already was registered! Instead, Lens will find the ID for model name \"an example model\" and use that (this is because model names must be unique, and are only associated with one ID). If you would like to run Lens again for the same model, but store the data somewhere else you will have to either change the name of the model or explicitly supply a different model_id."
+    "Note that if you run the above a second time, the model doesn't have to be registered again - it already was registered! Instead, Lens will look up the model name \"an example model\" on the governance app and use that. If you would like to run Lens again for the same model, but store the data somewhere else you will have to change the name of the model."
    ]
   },
   {
@@ -390,7 +449,7 @@
    "source": [
     "#### Registering a Model to Use Case\n",
     "\n",
-    "**Use Cases** can also be used. If CredoGovernance has a Use Case ID, the model will automatically be associated with that Use Case ID"
+    "**Use Cases** can also be used. If CredoGovernance has a Use Case, the model will automatically be associated with that Use Case."
    ]
   },
   {
@@ -400,7 +459,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gov = cl.CredoGovernance(use_case_id=\"your-use-case-id\")\n",
+    "gov = cl.CredoGovernance(use_case_name=\"your-use-case-name\")\n",
     "gov.register(model_name='my_model')"
    ]
   },
@@ -421,7 +480,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gov = cl.CredoGovernance(use_case_id=\"your-use-case-id\")\n",
+    "gov = cl.CredoGovernance(use_case_name=\"your-use-case-name\")\n",
     "gov.register(training_dataset_name='my_data',\n",
     "             dataset_name='my_data',\n",
     "             model_name='my_model')"
@@ -517,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/lens_demos/binaryclassification.ipynb
+++ b/docs/notebooks/lens_demos/binaryclassification.ipynb
@@ -501,9 +501,9 @@
     "# governance -> automatic alignment spec\n",
     "# incorporation\n",
     "gov = CredoGovernance(\n",
-    "    use_case_id = \"{example_id}\",\n",
-    "    model_id = \"{example_id}\",\n",
-    "    data_id = \"\"\n",
+    "    use_case_name = \"{example_name}\",\n",
+    "    model_name = \"{example_name}\",\n",
+    "    dataset_name = \"\"\n",
     ")\n",
     "\"\"\"\n",
     "alignment_spec = {\n",
@@ -799,7 +799,7 @@
    "hash": "8d7eb8a87bb83596f4cd5aeb66d856dad2a9bb65fe804cea051250e36746a46f"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit ('pip_dev': conda)",
+   "display_name": "Python 3.9.0 64-bit",
    "name": "python3"
   },
   "language_info": {


### PR DESCRIPTION
## Change description
We are transitioning from IDs to names in the interface in Lens. This happens by using the CredoGovernance object to hide IDs and handle transitions between names and IDs.

One place where this is an issue is in recording which dataset is associated with each metric. Users are potentially in an air-gapped situation where we cannot get the ID corresponding to a particular dataset name. As a result, we need to associate metrics with `dataset_name` rather than `dataset_id`. @aproxacs , let's meet briefly to discuss this.