### PR TITLE
added basic computational efficiency inference module

### DIFF
--- a/credoai/modules/__init__.py
+++ b/credoai/modules/__init__.py
@@ -12,6 +12,7 @@ base = 'credoai.modules'
 modules = [
     'dataset_modules.dataset_fairness',
     'dataset_modules.dataset_profiling',
+    'model_modules.computational_efficiency',
     'model_modules.fairness_nlp',
     'model_modules.fairness_base',
     'model_modules.performance_base',

--- a/credoai/modules/model_modules/computational_efficiency.py
+++ b/credoai/modules/model_modules/computational_efficiency.py
@@ -52,6 +52,7 @@ class ComputationalEfficiencyModule(CredoModule):
             )
 
     def _inference_efficiency(self):
+        """Estimates time to predict 1000 records"""
         t1 = perf_counter()
         out = self.prediction_fun(self.X)
         t2 = perf_counter()

--- a/credoai/modules/model_modules/computational_efficiency.py
+++ b/credoai/modules/model_modules/computational_efficiency.py
@@ -1,0 +1,62 @@
+from credoai.modules.credo_module import CredoModule
+from credoai.utils.common import NotRunError
+from time import perf_counter
+import pandas as pd
+
+class ComputationalEfficiencyModule(CredoModule):
+    """
+    Computational Efficiency module for Credo AI. 
+
+    Outputs inference time
+
+    Parameters
+    ----------
+    prediction_fun : callable
+        Function that takes in X and outputs some prediction
+    X : data
+        Data passed to prediction_fun to perform inference. Must instantiate
+        __len__
+    """
+    def __init__(self, prediction_fun, X):
+        self.prediction_fun = prediction_fun
+        self.X = X
+
+    def run(self):
+        """
+        Run computational inference module
+           
+        Returns
+        -------
+        self
+        """
+        self.results = {'computational_efficiency_inference': self._inference_efficiency()}
+        return self
+        
+    def prepare_results(self):
+        """Prepares results for Credo AI's governance platform
+
+        Returns
+        -------
+        pd.DataFrame
+
+        Raises
+        ------
+        NotRunError
+            Occurs if self.run is not called yet to generate the raw assessment results
+        """
+        if self.results is not None:
+            return self.results
+        else:
+            raise NotRunError(
+                "Results not created yet. Call 'run' with appropriate arguments before preparing results"
+            )
+
+    def _inference_efficiency(self):
+        t1 = perf_counter()
+        out = self.prediction_fun(self.X)
+        t2 = perf_counter()
+        time_in_ms = (t2-t1)*1000
+        # calculate for batches of 1000
+        time_per_batch = time_in_ms/len(self.X)*1000
+        return time_per_batch
+        

--- a/credoai/modules/model_modules/fairness_base.py
+++ b/credoai/modules/model_modules/fairness_base.py
@@ -78,7 +78,7 @@ class FairnessModule(PerformanceModule):
         return self
         
     def prepare_results(self, filter=None):
-        """prepares fairness and disaggregated results to Credo AI
+        """Prepares results for Credo AI's governance platform
 
         Structures results for export as a dataframe with appropriate structure
         for exporting. See credoai.modules.credo_module.

--- a/credoai/modules/model_modules/performance_base.py
+++ b/credoai/modules/model_modules/performance_base.py
@@ -70,10 +70,7 @@ class PerformanceModule(CredoModule):
             
         Returns
         -------
-        dict
-            Dictionary containing one pandas Dataframes:
-                - "disaggregated results": The disaggregated performance metrics, along with acceptability and risk
-            as columns
+        self
         """
         self.results = {'overall_performance': self.get_overall_metrics()}
         if self.perform_disaggregation:
@@ -81,7 +78,7 @@ class PerformanceModule(CredoModule):
         return self
         
     def prepare_results(self, filter=None):
-        """prepares fairness and disaggregated results to Credo AI
+        """Prepares results for Credo AI's governance platform
 
         Structures results for export as a dataframe with appropriate structure
         for exporting. See credoai.modules.credo_module.

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -28,10 +28,11 @@ def test_lens_with_model():
     results = lens.run_assessments().get_results()
     metric = results["validation"]["Fairness"]["fairness"].index[0]
     score = round(results["validation"]["Fairness"]["fairness"].iloc[0]["value"], 2)
-
+    expected_assessments = {'DatasetFairness', 'DatasetProfiling', 'Fairness', 'Performance', 'ComputationalEfficiency'}
+    
     assert metric == "precision_score"
     assert score == 0.33
-    assert set([a.name for a in lens.get_assessments(flatten=True)]) == {'DatasetFairness', 'DatasetProfiling', 'Fairness', 'Performance'} 
+    assert set([a.name for a in lens.get_assessments(flatten=True)]) == expected_assessments 
     assert lens.assessments["validation"]['Fairness'].initialized_module.metrics == ['precision_score']
 
 def test_lens_without_model():


### PR DESCRIPTION
## Change description
Small module that calculates the average time of inference for a batch of 1000. Separated into a separate module (rather than performance) because inference _has_ to happen within the module.

This will connect with new risk issues introduced in this [fast-follow PR](https://github.com/credo-ai/rai-service/pull/36)

Example:
<img width="683" alt="image" src="https://user-images.githubusercontent.com/85892367/167953398-0147be37-c7a9-4dbe-bc0f-6ddfa4b5db6f.png">
