### PR TITLE
fixed concatenation issue leading to incorrect infographic aspects

### DIFF
--- a/credoai/modules/model_modules/performance_base.py
+++ b/credoai/modules/model_modules/performance_base.py
@@ -157,8 +157,8 @@ class PerformanceModule(CredoModule):
             Dataframe containing the input arrays
         """
         df = pd.DataFrame({'true': self.y_true,
-                           'pred': self.y_pred}).reset_index(drop=True)
-        df = df.join(self.get_sensitive_features())
+                           'pred': self.y_pred})
+        df = df.join(self.get_sensitive_features().reset_index(drop=True))
         if self.y_prob is not None:
             y_prob_df = pd.DataFrame(self.y_prob)
             y_prob_df.columns = [

--- a/docs/notebooks/governance_integration.ipynb
+++ b/docs/notebooks/governance_integration.ipynb
@@ -82,7 +82,9 @@
     "\n",
     "Building off of the [quickstart notebook](https://credoai-lens.readthedocs.io/en/latest/notebooks/quickstart.html), let's look at how you can export to a Use Case on the Governance App. We only have to add two new lines.\n",
     "\n",
-    "**Note** The below will fail unless you change \"assessment-spec-destination\" to a assessment-spec-destination related to an assessment spec actually defined in your Governance app! \n",
+    "**Note** \n",
+    "\n",
+    "The below will fail unless you change \"assessment-spec-destination\" to an assessment-spec-destination related to an assessment spec actually defined in your Governance app! \n",
     "\n",
     "The assessment-spec will have the following form:\n",
     "`use_cases/{use_case_id}/models/{model_id}/assessment_spec`"


### PR DESCRIPTION
## Change description
This bug:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/85892367/173753663-cdd235d1-46e1-40ae-a549-7d9694deef27.png">

Was related to the sensitive feature dataframe not relating to the X. I've fixed it within the fairness module, though I think updating credodata would be better long term.