### PR TITLE
Always upload the pytest coverage log as an artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
           retval=$?
           cat pytest-coverage.txt
           exit $retval
+      - name: my-artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-coverage
+          path: pytest-coverage.txt
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:


### PR DESCRIPTION
## Change description

We want to store the pytest-coverage.txt file as an artifact on all test runs.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
