### PR TITLE
fix pandas_profiling version to 3.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ scipy>=1.8.1
 # Required for reporting
 jupyterlab>=3.2.8
 ipywidgets>=7.6.5
-pandas_profiling>=3.1.0
+pandas_profiling==3.1.0


### PR DESCRIPTION
pandas-profiling 3.2.0 uses MarkupSafe 2.1.1, this causes error while loading lib. So fix the version to 3.1.0, which uses MarkupSafe 2.0.1

Related to https://github.com/credo-ai/credoai_lens/issues/141