### PR TITLE
changes

### DIFF
--- a/credoai/evaluators/evaluator.py
+++ b/credoai/evaluators/evaluator.py
@@ -23,13 +23,11 @@ class Evaluator(ABC):
 
     @results.setter
     def results(self, results):
-        # TODO: validation to add after evaluators are refactored
-
-        # if not isinstance(results, list):
-        #     raise ValidationError("Results must be a list")
-        # for result in results:
-        #     if not isinstance(result, EvidenceContainer):
-        #         raise ValidationError("All results must be EvidenceContainers")
+        if not isinstance(results, list):
+            raise ValidationError("Results must be a list")
+        for result in results:
+            if not isinstance(result, EvidenceContainer):
+                raise ValidationError("All results must be EvidenceContainers")
         self._results = results
 
     @property
@@ -39,9 +37,9 @@ class Evaluator(ABC):
         pass
 
     @property
+    @abstractmethod
     def required_artifacts(self):
-        """Used to define a unique identifier for the specific evaluator"""
-        return inspect.getfullargspec(self._setup).args[1:]
+        pass
 
     def __call__(self, **kwargs):
         """

--- a/credoai/evaluators/performance.py
+++ b/credoai/evaluators/performance.py
@@ -193,6 +193,7 @@ class Performance(Evaluator):
                 var_name="type",
             )
         )
+        disaggregated_results.name = "disaggregated_performance"
 
         if disaggregated_results.empty:
             global_logger.warn("No disaggregated metrics could be calculated.")

--- a/credoai/evaluators/performance.py
+++ b/credoai/evaluators/performance.py
@@ -2,16 +2,16 @@ from collections import defaultdict
 from typing import List, Union
 
 import pandas as pd
-from absl import logging
 from credoai.artifacts import TabularData
 from credoai.evaluators import Evaluator
+from credoai.evidence.containers import MetricContainer, TableContainer
 from credoai.modules.metric_constants import MODEL_METRIC_CATEGORIES
 from credoai.modules.metrics import Metric, find_metrics
+from credoai.utils import global_logger
 from credoai.utils.common import NotRunError, ValidationError, to_array
 from fairlearn.metrics import MetricFrame
 from scipy.stats import norm
 from sklearn.utils import check_consistent_length
-from credoai.evidence.containers import TableContainer, MetricContainer
 
 
 class Performance(Evaluator):
@@ -82,10 +82,7 @@ class Performance(Evaluator):
         -------
         self
         """
-        self.results = {"overall_performance": self.get_overall_metrics()}
-        if self.perform_disaggregation:
-            self.results.update(self.get_disaggregated_performance())
-        self.results = self._prepare_results()
+        self._prepare_results()
         return self
 
     def _prepare_results(self):
@@ -102,24 +99,10 @@ class Performance(Evaluator):
         NotRunError
             Occurs if self.run is not called yet to generate the raw assessment results
         """
-        if self.results is not None:
-            if "overall_performance" in self.results:
-                overall = self.results["overall_performance"].copy()
-                overall = overall.reset_index().rename({"index": "type"}, axis=1)
-
-            if self.perform_disaggregation:
-                disaggregated_df = self.results[f"disaggregated_performance"].copy()
-                disaggregated_df = disaggregated_df.reset_index().melt(
-                    id_vars=[disaggregated_df.index.name, "subtype"],
-                    var_name="type",
-                )
-                # disaggregated_df["sensitive_feature"] = self.sensitive_features.name
-
-            return [MetricContainer(overall), TableContainer(disaggregated_df)]
-        else:
-            raise NotRunError(
-                "Results not created yet. Call 'run' with appropriate arguments before preparing results"
-            )
+        self.results = [
+            MetricContainer(self.get_overall_metrics()),
+            TableContainer(self.get_disaggregated_performance()),
+        ]
 
     def update_metrics(self, metrics, replace=True):
         """replace metrics
@@ -181,9 +164,9 @@ class Performance(Evaluator):
                 .to_frame()
                 .assign(subtype="overall_performance")
             )
-            return output_series
+            return output_series.reset_index().rename({"index": "type"}, axis=1)
         else:
-            logging.warn("No overall metrics could be calculated.")
+            global_logger.warn("No overall metrics could be calculated.")
 
     def get_disaggregated_performance(self):
         """Return performance metrics for each group
@@ -198,16 +181,21 @@ class Performance(Evaluator):
         pandas.DataFrame
             The disaggregated performance metrics
         """
-        disaggregated_results = {}
         disaggregated_df = pd.DataFrame()
         for metric_frame in self.metric_frames.values():
             df = metric_frame.by_group.copy().convert_dtypes()
             disaggregated_df = pd.concat([disaggregated_df, df], axis=1)
-        disaggregated_results["disaggregated_performance"] = disaggregated_df.assign(
-            subtype="disaggregated_performance"
+        disaggregated_results = (
+            disaggregated_df.assign(subtype="disaggregated_performance")
+            .reset_index()
+            .melt(
+                id_vars=[disaggregated_df.index.name, "subtype"],
+                var_name="type",
+            )
         )
-        if not disaggregated_results:
-            logging.warn("No disaggregated metrics could be calculated.")
+
+        if disaggregated_results.empty:
+            global_logger.warn("No disaggregated metrics could be calculated.")
         return disaggregated_results
 
     def get_sensitive_feature(self):
@@ -251,7 +239,7 @@ class Performance(Evaluator):
             if not isinstance(metric, Metric):
                 raise ValidationError("Metric is not of type credoai.metric.Metric")
             if metric.metric_category == "FAIRNESS":
-                logging.info(
+                global_logger.info(
                     f"fairness metric, {metric_name}, unused by PerformanceModule"
                 )
                 pass
@@ -261,7 +249,9 @@ class Performance(Evaluator):
                 else:
                     performance_metrics[metric_name] = metric
             else:
-                logging.warning(f"{metric_name} failed to be used by FairnessModule")
+                global_logger.warning(
+                    f"{metric_name} failed to be used by FairnessModule"
+                )
                 failed_metrics.append(metric_name)
 
         return (performance_metrics, prob_metrics, failed_metrics)

--- a/credoai/evaluators/privacy.py
+++ b/credoai/evaluators/privacy.py
@@ -137,25 +137,6 @@ class Privacy(Evaluator):
 
         return self
 
-    def _validate_arguments(self):
-        # Check types, all three are needed -> None is not allowed in this case
-        if not isinstance(self.training_data, TabularData):
-            raise ValidationError("Training data is not of type TabularData.")
-        if not isinstance(self.assessment_data, TabularData):
-            raise ValidationError("Test data is not of type TabularData")
-        if not isinstance(self.model, ClassificationModel):
-            raise ValidationError("Model is not of type ClassificationModel.")
-        # Check attack feature in dataset
-        if self.attack_feature:
-            if not self.attack_feature in self.training_data.X.columns:
-                raise ValidationError(
-                    f"Feature {self.attack_feature} not in training data."
-                )
-            if not self.attack_feature in self.assessment_data.X.columns:
-                raise ValidationError(
-                    f"Feature {self.attack_feature} not in test data."
-                )
-
     def _prepare_results(self):
         """Prepares results for export to Credo AI's Governance App
 
@@ -180,6 +161,25 @@ class Privacy(Evaluator):
             raise ValueError(
                 "Results not created yet. Call 'evaluate' to create results"
             )
+
+    def _validate_arguments(self):
+        # Check types, all three are needed -> None is not allowed in this case
+        if not isinstance(self.training_data, TabularData):
+            raise ValidationError("Training data is not of type TabularData.")
+        if not isinstance(self.assessment_data, TabularData):
+            raise ValidationError("Test data is not of type TabularData")
+        if not isinstance(self.model, ClassificationModel):
+            raise ValidationError("Model is not of type ClassificationModel.")
+        # Check attack feature in dataset
+        if self.attack_feature:
+            if not self.attack_feature in self.training_data.X.columns:
+                raise ValidationError(
+                    f"Feature {self.attack_feature} not in training data."
+                )
+            if not self.attack_feature in self.assessment_data.X.columns:
+                raise ValidationError(
+                    f"Feature {self.attack_feature} not in test data."
+                )
 
     def _general_attack_method(self, attack_details):
         """

--- a/credoai/evidence/containers.py
+++ b/credoai/evidence/containers.py
@@ -63,7 +63,7 @@ class TableContainer(EvidenceContainer):
         super().__init__(Table, df)
 
     def to_evidence(self, id, **metadata):
-        return self.evidence_class(id, self._df, **metadata)
+        return [self.evidence_class(id, self._df, **metadata)]
 
     def _validate(self, df):
         pass

--- a/credoai/evidence/containers.py
+++ b/credoai/evidence/containers.py
@@ -45,10 +45,10 @@ class MetricContainer(EvidenceContainer):
     def __init__(self, df):
         super().__init__(Metric, df)
 
-    def to_evidence(self, id, **metadata):
+    def to_evidence(self, **metadata):
         evidence = []
         for _, data in self._df.iterrows():
-            evidence.append(self.evidence_class(id, data, **metadata))
+            evidence.append(self.evidence_class(**data, **metadata))
         return evidence
 
     def _validate(self, df):
@@ -62,8 +62,11 @@ class TableContainer(EvidenceContainer):
     def __init__(self, df):
         super().__init__(Table, df)
 
-    def to_evidence(self, id, **metadata):
-        return [self.evidence_class(id, self._df, **metadata)]
+    def to_evidence(self, **metadata):
+        return [self.evidence_class(self._df.name, self._df, **metadata)]
 
     def _validate(self, df):
-        pass
+        try:
+            df.name
+        except AttributeError:
+            raise ValidationError("DataFrame must have a 'name' attribute")

--- a/credoai/evidence/evidence.py
+++ b/credoai/evidence/evidence.py
@@ -1,51 +1,40 @@
 import pprint
 from abc import ABC, abstractmethod
 from datetime import datetime
-from turtle import update
 from typing import Optional, Tuple
 
-from pandas import Series, DataFrame
+from credoai.utils import ValidationError
+from pandas import DataFrame, Series
 
 
 class Evidence(ABC):
     def __init__(
         self,
-        id: str,
         type: str,
         metadata: Optional[dict] = None,
     ):
-        self.id = id
         self.type = type
         self.metadata = metadata if metadata else {}
         self.creation_time: str = datetime.utcnow().isoformat()
         self._validate()
 
     def struct(self):
+        """Structure of evidence"""
         structure = {
-            "id": self.id,
             "type": self.type,
-            "label": self._label(),
-            # "metadata": self.metadata,
-            "data": self._data(),
+            "label": self.label(),
             "creation_time": self.creation_time,
-        } | self._update_struct()
+            # "metadata": self.metadata,
+        } | self._struct()
         return structure
 
-    def _update_struct(self):
+    def _struct(self):
+        """Function to reflect additional structure of child classes"""
         return {}
 
     @property
     @abstractmethod
-    def _data(self):
-        """
-        Adds evidence type specific data
-        """
-        data = {}
-        return data
-
-    @property
-    @abstractmethod
-    def _label(self):
+    def label(self):
         """
         Adds evidence type specific label
         """
@@ -62,54 +51,17 @@ class Evidence(ABC):
 class Metric(Evidence):
     """
     Metric Evidence
-    """
-
-    def __init__(
-        self,
-        id: str,
-        data: Series,
-        confidence_interval: Tuple[float, float] = None,
-        confidence_level: int = None,
-        **metadata
-    ):
-        self.confidence_interval = confidence_interval
-        self.confidence_level = confidence_level
-        self.data = data
-        self.metadata = metadata
-
-        super().__init__(id, "metric", self.metadata)
-
-    def _data(self):
-        value_type = [x for x in self.data.index if x not in ["type", "subtype"]]
-        return {
-            "value": self.data[value_type].to_dict(),
-        }
-
-    def _label(self):
-        label = {
-            "metric_type": self.data.type,
-            "calculation": self.data.subtype,
-        } | self.metadata
-        return label
-
-    def _update_struct(self):
-        return {
-            "confidence_interval": self.confidence_interval,
-            "confidence_level": self.confidence_level,
-        }
-
-
-class Table(Evidence):
-    """
-    Table Evidence
-
 
     Parameters
     ----------
-    label : string
+    type : string
         short identifier for metric.
-    data : pd.DataFrame
-        a pandas DataFrame to use as evidence
+    value : float
+        metric value
+    confidence_interval : [float, float]
+        [lower, upper] confidence interval
+    confidence_level : int
+        Level of confidence for the confidence interval (e.g., 95%)
     model_name : str, optional
         Name of Model, default None
     data_name : str, optional
@@ -119,19 +71,63 @@ class Table(Evidence):
         displayed in the governance app
     """
 
-    def __init__(self, id: str, data: DataFrame, **metadata):
+    def __init__(
+        self,
+        type: str,
+        value: float,
+        confidence_interval: Tuple[float, float] = None,
+        confidence_level: int = None,
+        **metadata
+    ):
+        self.type = type
+        self.value = value
+        self.confidence_interval = confidence_interval
+        self.confidence_level = confidence_level
+        self.metadata = metadata
+        super().__init__("metric", self.metadata)
+
+    def label(self):
+        label = {
+            "metric_type": self.type,
+        } | self.metadata
+        return label
+
+    def _struct(self):
+        return {
+            "value": self.value,
+            "confidence_interval": self.confidence_interval,
+            "confidence_level": self.confidence_level,
+        }
+
+    def _validate(self):
+        if self.confidence_interval and not self.confidence_level:
+            raise ValidationError
+
+
+class Table(Evidence):
+    """
+    Table Evidence
+
+
+    Parameters
+    ----------
+    data : str
+        a pandas DataFrame to use as evidence
+    metadata : dict, optional
+        Arbitrary keyword arguments to append to metric as metadata. These will be
+        displayed in the governance app
+    """
+
+    def __init__(self, name: str, data: DataFrame, **metadata):
+        self.name = name
         self.data = data
         self.metadata = metadata
 
-        super().__init__(id, "table", self.metadata)
+        super().__init__("table", self.metadata)
 
-    def _data(self):
-        value_type = [x for x in self.data.columns if x not in ["subtype"]]
-        return {
-            "value": self.data[value_type].to_dict(orient="split"),
-        }
+    def _struct(self):
+        return {"data": self.data.to_csv()}
 
-    def _label(self):
-        label = {"calculation": "-".join(list(set(self.data.subtype)))} | self.metadata
-
+    def label(self):
+        label = {"table_name": self.name} | self.metadata
         return label

--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -152,7 +152,7 @@ class Lens:
         Create evidences for the platform from the pipeline results.
         """
         labels = {
-            "model_id": self.model.name if self.model else None,
+            "model_name": self.model.name if self.model else None,
             "dataset_name": self.assessment_data.name if self.assessment_data else None,
             "sensitive_features": [
                 x for x in self.assessment_data.sensitive_features.columns
@@ -161,7 +161,7 @@ class Lens:
         all_results = flatten_list([x["results"] for x in self.pipeline_results])
         evidences = []
         for result in all_results:
-            evidences += result.to_evidence("id", **labels)
+            evidences += result.to_evidence(**labels)
         return evidences
 
     def get_results(self) -> Dict:

--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -1,15 +1,14 @@
-import logging
 import re
-from typing import Dict, List, Union
 import uuid
 from inspect import isclass
+from typing import Dict, List, Union
 
 from credoai.artifacts import Data, Model
 from credoai.evaluators.evaluator import Evaluator
 from credoai.lens.utils import build_list_of_evaluators, log_command
-from credoai.utils.common import ValidationError
+from credoai.utils import global_logger
+from credoai.utils.common import ValidationError, flatten_list
 
-logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
 # Custom type
 Pipeline = List[Union[Evaluator, tuple[Evaluator, str, dict]]]
 
@@ -52,7 +51,7 @@ class Lens:
         self.gov = None
         self.pipeline: dict = {}
         self.command_list: list = []
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = global_logger
         # If a list of steps is passed create the pipeline
         if pipeline:
             self._generate_pipeline(pipeline)
@@ -136,7 +135,7 @@ class Lens:
         Run the main loop across all the pipeline steps.
         """
         if len(self.pipeline) == 0:
-            logging.info("Empty pipeline: proceeding with defaults...")
+            self.logger.info("Empty pipeline: proceeding with defaults...")
             all_evaluators = build_list_of_evaluators()
             self._generate_pipeline(all_evaluators)
         # Can  pass pipeline directly
@@ -159,13 +158,11 @@ class Lens:
                 x for x in self.assessment_data.sensitive_features.columns
             ],
         }
-        all_evidences = [x["results"] for x in self.pipeline_results]
-
-        all_evidences = self.flatten_list(all_evidences)
-        all_evidences = [x.to_evidence("id", **labels) for x in all_evidences]
-        all_evidences = self.flatten_list(all_evidences)
-
-        return [x.struct() for x in all_evidences]
+        all_results = flatten_list([x["results"] for x in self.pipeline_results])
+        evidences = []
+        for result in all_results:
+            evidences += result.to_evidence("id", **labels)
+        return evidences
 
     def get_results(self) -> Dict:
         """
@@ -174,20 +171,16 @@ class Lens:
         Returns
         -------
         Dict
-            The format of the dictionaryu is Pipeline step id: results
+            The format of the dictionary is Pipeline step id: results
         """
-
-        res = {}
-        for x in self.pipeline_results:
-            if isinstance(x["results"], list):
-                value = [i.df for i in x["results"]]
-            else:
-                value = x["results"].df
-            res[x["id"]] = value
+        res = {x["id"]: [i.df for i in x["results"]] for x in self.pipeline_results}
         return res
 
     def get_command_list(self):
         return print("\n".join(self.command_list))
+
+    def get_evaluators(self):
+        return [i["evaluator"] for i in self.pipeline.values()]
 
     def push(self):
         """
@@ -258,14 +251,3 @@ class Lens:
             return step[pos]
         except IndexError:
             return None
-
-    @staticmethod
-    def flatten_list(mixl):
-        flattened = []
-        for i in mixl:
-            if hasattr(i, "__iter__"):
-                for j in i:
-                    flattened.append(j)
-            else:
-                flattened.append(i)
-        return flattened

--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -147,7 +147,7 @@ class Lens:
             )
         return self
 
-    def get_evidences(self):
+    def get_evidence(self):
         """
         Create evidences for the platform from the pipeline results.
         """

--- a/credoai/utils/common.py
+++ b/credoai/utils/common.py
@@ -53,6 +53,7 @@ def update_dictionary(d, u):
 
 
 def wrap_list(obj):
+    """Ensures object is an iterable"""
     if type(obj) == str:
         obj = [obj]
     elif obj is None:


### PR DESCRIPTION
## Change description
* Require that the results created by an evaluator is a list of containers. Cannot be a single container!
* Simplified Performance evaluator. There was functionality kept over from the previous module/assessment divide.
    * For instance, results were formatted by `prepare_results`. They can now be manipulated as dfs within the result generating functions. 
    * No need for `NotRunError`
 * Lens - simplified some things
     * Because all results will always be lists, could eliminate some if statements
     * `flatten_list` was already a util in common
     * Added a `get_evaluators` function

Evidence changes:
* The data property seems to obscure what the evidence is about. I added back the _struct function (which should be filled out by the children), and that should add keys to the struct dictionary. Passing a nested dictionary in data didn't seem correct.
* Added validation to make sure the table has a name
* Removed ID from evidences. Doesn't seem necessary

## ToDo
* Do similar simplification for other evaluators



