### PR TITLE
Can register without policy_pack_key

### DIFF
--- a/credoai/governance/credo_api.py
+++ b/credoai/governance/credo_api.py
@@ -26,7 +26,7 @@ class CredoApi:
         """
         self._client = client
 
-    def get_assessment_plan_url(self, use_case_name: str, policy_pack_key: str):
+    def get_assessment_plan_url(self, use_case_name: str, policy_pack_key: str = None):
         """
         Convert use_case_name and policy_pack_key to assessment_plan_url
 
@@ -36,6 +36,7 @@ class CredoApi:
             name of a use case
         policy_pack_key : str
             policy pack key, ie: FAIR
+            If it is None, it gets the first resgisterd policy pack in use case
 
         Returns
         -------
@@ -51,16 +52,27 @@ class CredoApi:
         """
 
         try:
-            path = f"assessment_plan_url?use_case_name={use_case_name}&policy_pack_key={policy_pack_key}"
+            path = f"assessment_plan_url?use_case_name={use_case_name}"
+            if policy_pack_key:
+                path += f"&policy_pack_key={policy_pack_key}"
             response = self._client.get(path)
             return response["url"]
         except HTTPError as error:
-            if error.response.status_code == 404:
-                global_logger.info(
-                    f"Use case ({use_case_name}) with policy pack({policy_pack_key}) does not exist"
-                )
+            global_logger.info(
+                f"Cannot find assessment plan URL of use case {use_case_name}"
+            )
+            data = error.response.json()
+            errors = data.get("errors", None)
+            if errors:
+                detail = errors[0]["detail"]
+                if error:
+                    global_logger.info(f"Error : {detail}")
+                else:
+                    raise error
+
                 return None
-            raise error
+            else:
+                raise error
 
     def get_assessment_plan(self, url: str):
         """

--- a/credoai/governance/governance.py
+++ b/credoai/governance/governance.py
@@ -108,7 +108,7 @@ class CredoGovernance:
         self._plan = None
 
         plan = None
-        if use_case_name and policy_pack_key:
+        if use_case_name:
             assessment_plan_url = self._api.get_assessment_plan_url(
                 use_case_name, policy_pack_key
             )

--- a/docs/notebooks/governance.ipynb
+++ b/docs/notebooks/governance.ipynb
@@ -90,9 +90,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'CredoGovernance' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/Users/chang/work/credo/credoai_lens/docs/notebooks/governance.ipynb Cell 7\u001b[0m in \u001b[0;36m<cell line: 7>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/chang/work/credo/credoai_lens/docs/notebooks/governance.ipynb#W5sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m config\u001b[39m.\u001b[39mload_config(\u001b[39m\"\u001b[39m\u001b[39mconfig_file_name\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/chang/work/credo/credoai_lens/docs/notebooks/governance.ipynb#W5sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m client \u001b[39m=\u001b[39m CredoApiClient(config\u001b[39m=\u001b[39mconfig)\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/chang/work/credo/credoai_lens/docs/notebooks/governance.ipynb#W5sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m gov \u001b[39m=\u001b[39m CredoGovernance(credo_api_client\u001b[39m=\u001b[39mclient)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'CredoGovernance' is not defined"
+     ]
+    }
+   ],
    "source": [
     "from credoai.governance.credo_api_client import CredoApiClient, CredoApiConfig\n",
     "\n",
@@ -150,12 +162,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-09-22 21:36:44,266 - lens - INFO - Successfully registered with 5 evidence requirements\n",
+      "2022-09-22 21:36:44,664 - lens - INFO - Successfully registered with 5 evidence requirements\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<credoai.evidence.evidence_requirement.EvidenceRequirement at 0x1537fc4f0>,\n",
+       " <credoai.evidence.evidence_requirement.EvidenceRequirement at 0x1537fc6a0>,\n",
+       " <credoai.evidence.evidence_requirement.EvidenceRequirement at 0x1537fc490>,\n",
+       " <credoai.evidence.evidence_requirement.EvidenceRequirement at 0x1537fc340>,\n",
+       " <credoai.evidence.evidence_requirement.EvidenceRequirement at 0x1537fc430>]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# With Use case name and Policy pack key\n",
     "gov.register(use_case_name=\"Keyboard Sensitivity\", policy_pack_key=\"NYCE\")\n",
+    "# If there is only one policy pack registered in the use case, you can omit policy_pack_key\n",
+    "gov.register(use_case_name=\"Keyboard Sensitivity\")\n",
     "gov.get_evidence_requirements()"
    ]
   },
@@ -166,7 +203,7 @@
    "outputs": [],
    "source": [
     "# With JSON file\n",
-    "gov.register(assessment_plan_file=\"/Users/chang/Downloads/assessment-plan-NYCE+1.json\")\n",
+    "gov.register(assessment_plan_file=\"/tmp/assessment-plan-NYCE+1.json\")\n",
     "gov.get_evidence_requirements()"
    ]
   },


### PR DESCRIPTION
## Change description
Now API server accepts assessment_plan_url without policy pack key, PR : https://github.com/credo-ai/credo-backend/pull/799
It will return the URL with the first registered policy pack.

```
gov.register(use_case_name=="Fraud Detector")
```

It is useful when the use case uses only one policy pack. 
