### PR TITLE
Updated pandas-profiling version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ scipy>=1.8.1
 # Required for reporting
 jupyterlab>=3.2.8
 ipywidgets>=7.6.5
-pandas_profiling==3.1.0
+pandas_profiling==3.3.0


### PR DESCRIPTION
Updated pandas-profiling version in the requirements file
This fixes `from pandas.core.base import DataError` error thrown in pandas-profiling module during `import credoai.lens`
We can also consider `pandas_profiling>=3.3.0` but this relaxation has caused issues like [here](https://github.com/credo-ai/credoai_lens/issues/141) in the past.