### PR TITLE
Fix/183 probability dependent metrics do not run not added to pipeline

### DIFF
--- a/credoai/evaluators/utils/fairlearn.py
+++ b/credoai/evaluators/utils/fairlearn.py
@@ -26,12 +26,12 @@ def setup_metric_frames(
             sensitive_features=sensitive_features,
         )
 
-        # for metrics that require the probabilities
-        prob_metric_frame = None
-        if y_prob is not None and prob_metrics:
-            metric_frames["prob"] = create_metric_frame(
-                prob_metrics,
-                y_prob,
-                sensitive_features=sensitive_features,
-            )
+    if y_prob is not None and prob_metrics:
+        metric_frames["prob"] = create_metric_frame(
+            prob_metrics,
+            y_prob[:, 1],
+            # sklearn probability metric functions expect a 1d array; predict_proba returns 2d array for binary outcome
+            y_true,
+            sensitive_features=sensitive_features,
+        )
     return metric_frames

--- a/credoai/evaluators/utils/fairlearn.py
+++ b/credoai/evaluators/utils/fairlearn.py
@@ -44,7 +44,10 @@ def setup_metric_frames(
                 sensitive_features=sensitive_features,
             )
         else:
-            raise ValidationError(
-                "Specified non-binary metric with probabilistic model. Multi-output probabilistic metrics not currently supported."
+            metric_frames["prob"] = create_metric_frame(
+                prob_metrics,
+                y_prob,
+                y_true,
+                sensitive_features=sensitive_features,
             )
     return metric_frames

--- a/credoai/evaluators/utils/fairlearn.py
+++ b/credoai/evaluators/utils/fairlearn.py
@@ -1,5 +1,6 @@
-from fairlearn.metrics import MetricFrame
 from credoai.utils import ValidationError
+
+from fairlearn.metrics import MetricFrame
 
 ########### General functions shared across evaluators ###########
 
@@ -28,26 +29,10 @@ def setup_metric_frames(
         )
 
     if y_prob is not None and prob_metrics:
-        if all(
-            # sklearn probability metric functions expect a 1d array
-            # predict_proba returns 2d array for binary outcome
-            # No current support for multi-output probabilistic metrics
-            [
-                "BINARY" in prob_metrics[key].metric_category
-                for key in prob_metrics.keys()
-            ]
-        ):
-            metric_frames["prob"] = create_metric_frame(
-                prob_metrics,
-                y_prob[:, 1],
-                y_true,
-                sensitive_features=sensitive_features,
-            )
-        else:
-            metric_frames["prob"] = create_metric_frame(
-                prob_metrics,
-                y_prob,
-                y_true,
-                sensitive_features=sensitive_features,
-            )
+        metric_frames["prob"] = create_metric_frame(
+            prob_metrics,
+            y_prob,
+            y_true,
+            sensitive_features=sensitive_features,
+        )
     return metric_frames


### PR DESCRIPTION
## Change description
1) Add `y_true` to `create_metric_frames()` call in `fairlearn.py` within if-statement for probabilistic metrics
2) Unindented if-block (see line 30 in fix branch), since probabilistic metrics are not necessarily performance metrics (putting `roc_auc_score` in Quickstart.ipynb pipeline alone without other metrics will make it so `roc_auc_score` doesn't get calculated).
3) Added check for whether the specified metric is meant to be for a binary prediction problem (rather than multi-output classification/probabilistic output). Sklearn's `predict_proba()` function outputs an array that has shape `(n_samples, n_classes)`. For binary problems, `y_true` will be `(n_samples, )` in our present handling, and `(n_samples, n_classes)` for a multi-output problem. The former causes a shape mismatch when calling the scoring function and so we need to select the column of `y_prob` corresponding to the positive class.
See discussion of `y_score` here: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html

## Type of change
- [X ] Bug fix (fixes an issue)

## Related issues

> Fix https://github.com/credo-ai/credoai_lens/issues/183
