### PR TITLE
Feat/table types

### DIFF
--- a/credoai/evidence/evidence.py
+++ b/credoai/evidence/evidence.py
@@ -138,8 +138,11 @@ class TableEvidence(Evidence):
 
     @property
     def data(self):
+        columns = [
+            {"value": k, "type": str(v)} for k, v in self._data.dtypes.iteritems()
+        ]
         return {
-            "columns": self._data.columns.tolist(),
+            "columns": columns,
             "value": self._data.values.tolist(),
         }
 
@@ -160,7 +163,7 @@ class ProfilerEvidence(Evidence):
 
     @property
     def data(self):
-        return self._data["results"].to_json()
+        return self._data["results"]
 
     @property
     def base_label(self):

--- a/credoai/evidence/evidence.py
+++ b/credoai/evidence/evidence.py
@@ -139,7 +139,7 @@ class TableEvidence(Evidence):
     @property
     def data(self):
         columns = [
-            {"value": k, "type": str(v)} for k, v in self._data.dtypes.iteritems()
+            {"value": k, "type": self._transform_type(v)} for k, v in self._data.dtypes.iteritems()
         ]
         return {
             "columns": columns,
@@ -150,6 +150,17 @@ class TableEvidence(Evidence):
     def base_label(self):
         label = {"table_name": self.name}
         return label
+
+    def _transform_type(self, pandas_type):
+        lookup = {
+            'int64': 'number',
+            'float64': 'number',
+            'object': 'str',
+            'category': 'str',
+            'datetime64': 'datetime'
+        }
+        final_type = str(pandas_type)
+        return lookup.get(final_type, final_type)
 
 
 class ProfilerEvidence(Evidence):


### PR DESCRIPTION
## Change description

Change the "columns "part of TabelEvidence to return types for the columns. This functionality is there to support the Platform to style the column outputs (e.g., rounding numbers)


Example:
```
'columns': [
  {'value': 'false_positive_rate', 'type': 'number'},
   {'value': 'true_positive_rate', 'type': 'number'},
   {'value': 'threshold', 'type': 'number'}
]
```