### PR TITLE
Make privacy python3.8 compatible

### DIFF
--- a/credoai/evaluators/privacy.py
+++ b/credoai/evaluators/privacy.py
@@ -144,8 +144,8 @@ class Privacy(Evaluator):
         """
 
         attacks_to_run = SUPPORTED_MEMBERSHIP_ATTACKS
-        if self.attack_feature:
-            attacks_to_run = attacks_to_run | SUPPORTED_ATTRIBUTE_ATTACKS
+        if self.attack_feature is not None:
+            attacks_to_run = {**attacks_to_run, **SUPPORTED_ATTRIBUTE_ATTACKS}
 
         attack_scores = {}
         for attack_name, attack_info in attacks_to_run.items():
@@ -156,7 +156,7 @@ class Privacy(Evaluator):
             [v for k, v in attack_scores.items() if "Membership" in k]
         )
 
-        if self.attack_feature:
+        if self.attack_feature is not None:
             attack_scores["AttributeInference-attack_score"] = max(
                 [v for k, v in attack_scores.items() if "Attribute" in k]
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 from credoai.artifacts import ClassificationModel, RegressionModel, TabularData
 from credoai.datasets import fetch_testdata
-from pandas import DataFrame, Series
 from pytest import fixture
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
+from credoai.datasets import fetch_creditdefault
 
 
 @fixture(scope="session")
@@ -15,6 +16,23 @@ def binary_data():
 @fixture(scope="session")
 def continuous_data():
     train_data, test_data = fetch_testdata(False, 1, 1, "continuous")
+    return {"train": train_data, "test": test_data}
+
+
+@fixture(scope="session")
+def credit_data():
+    data = fetch_creditdefault()
+    X = data["data"].iloc[0:100]
+    X = X.drop(columns=["SEX"])
+    y = data["target"].iloc[0:100].astype(int)
+    (
+        X_train,
+        X_test,
+        y_train,
+        y_test,
+    ) = train_test_split(X, y, random_state=42)
+    train_data = {"X": X_train, "y": y_train}
+    test_data = {"X": X_test, "y": y_test}
     return {"train": train_data, "test": test_data}
 
 
@@ -76,3 +94,33 @@ def regression_train_data(continuous_data):
         y=train["y"],
         sensitive_features=train["sensitive_features"],
     )
+
+
+@fixture(scope="session")
+def credit_classification_model(credit_data):
+    model = RandomForestClassifier()
+    model.fit(credit_data["train"]["X"], credit_data["train"]["y"])
+    credo_model = ClassificationModel("credit_default_classifier", model)
+    return credo_model
+
+
+@fixture(scope="session")
+def credit_assessment_data(credit_data):
+    test = credit_data["test"]
+    assessment_data = TabularData(
+        name="UCI-credit-default-test",
+        X=test["X"],
+        y=test["y"],
+    )
+    return assessment_data
+
+
+@fixture(scope="session")
+def credit_training_data(credit_data):
+    train = credit_data["train"]
+    training_data = TabularData(
+        name="UCI-credit-default-test",
+        X=train["X"],
+        y=train["y"],
+    )
+    return training_data

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -68,16 +68,17 @@ class TestModelFairness(Base_Evaluator_Test):
         self.pipeline.pipeline = {}
 
 
-class TestPrivacy(Base_Evaluator_Test):
-    evaluator = Privacy(attack_feature="experience")
-
-    def test_add(self):
-        self.pipeline.add(self.evaluator)
-        assert len(self.pipeline.pipeline) == 1
-
-    def test_run(self):
-        self.pipeline.run()
-        assert self.pipeline.get_results()
+def test_privacy(
+    credit_classification_model, credit_assessment_data, credit_training_data
+):
+    lens = Lens(
+        model=credit_classification_model,
+        assessment_data=credit_assessment_data,
+        training_data=credit_training_data,
+    )
+    lens.add(Privacy(attack_feature="MARRIAGE"))
+    lens.run()
+    assert lens.get_results()
 
 
 class TestDataFairness(Base_Evaluator_Test):


### PR DESCRIPTION
##  Python3.8 compatible privacy module

- Removed new syntax for dictionary join
- Fixed minor logic error in privacy package
- Added credit dataset to test, needed for AttributeInferenceBaseline testing.