### PR TITLE
Assessment data validation fix

### DIFF
--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -353,7 +353,7 @@ class Lens:
         ------
         ValidationError
         """
-        if not isinstance(self.assessment_data, Data):
+        if not (isinstance(self.assessment_data, Data) or self.assessment_data is None):
             raise ValidationError(
                 "Assessment data should inherit from credoai.artifacts.Data"
             )


### PR DESCRIPTION
## Quick fix

Validation of arguments in Lens didn't allow for assessment_data being optional.