### PR TITLE
Bug/210/shap error multi class

### DIFF
--- a/credoai/evaluators/feature_drift.py
+++ b/credoai/evaluators/feature_drift.py
@@ -42,7 +42,7 @@ class FeatureDrift(Evaluator):
         by default False
     """
 
-    def __init__(self, buckets: int = 10, buckettype="bins", csi_calculation=True):
+    def __init__(self, buckets: int = 10, buckettype="bins", csi_calculation=False):
 
         self.bucket_number = buckets
         self.buckettype = buckettype

--- a/credoai/evaluators/feature_drift.py
+++ b/credoai/evaluators/feature_drift.py
@@ -42,7 +42,7 @@ class FeatureDrift(Evaluator):
         by default False
     """
 
-    def __init__(self, buckets: int = 10, buckettype="bins", csi_calculation=False):
+    def __init__(self, buckets: int = 10, buckettype="bins", csi_calculation=True):
 
         self.bucket_number = buckets
         self.buckettype = buckettype
@@ -50,7 +50,7 @@ class FeatureDrift(Evaluator):
         self.percentage = False
         super().__init__()
 
-    name = "Feature Drift"
+    name = "FeatureDrift"
 
     required_artifacts = {"model", "assessment_data", "training_data"}
 
@@ -81,10 +81,10 @@ class FeatureDrift(Evaluator):
 
     def evaluate(self):
         prediction_psi = self._calculate_psi_on_prediction()
-        self.results = [MetricContainer(prediction_psi, self.get_container_info())]
+        self.results = [MetricContainer(prediction_psi, **self.get_container_info())]
         if self.csi_calculation:
             csi = self._calculate_csi()
-            self.results.append(TableContainer(csi, self.get_container_info()))
+            self.results.append(TableContainer(csi, **self.get_container_info()))
         return self
 
     def _calculate_psi_on_prediction(self) -> DataFrame:

--- a/credoai/evaluators/shap.py
+++ b/credoai/evaluators/shap.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Dict, List, Optional, Union
 
 from numpy import abs, mean
@@ -108,11 +109,8 @@ class ShapExplainer(Evaluator):
 
         ## Sample specific results
         if self.samples_ind:
-            labels = {"ordered_feature_names": self.shap_values.feature_names}
             ind_res = self._get_mult_sample_shapley_values()
-            self.results += [
-                TableContainer(ind_res, **self.get_container_info(labels=labels))
-            ]
+            self.results += [TableContainer(ind_res, **self.get_container_info())]
         return self
 
     def _setup_shap(self):
@@ -135,6 +133,23 @@ class ShapExplainer(Evaluator):
             explainer = Explainer(self.model.predict, data_summary)
         # Generating the actual values calling the specific Shap function
         self.shap_values = explainer(self.X)
+
+        # Define values dataframes and classes variables depending on
+        # the shape of the returned values. This accounts for multi class
+        # classification
+        self.classes = [None]
+        s_values = self.shap_values.values
+        if len(s_values.shape) == 2:
+            self.values_df = [DataFrame(s_values)]
+        elif len(s_values.shape) == 3:
+            self.values_df = [
+                DataFrame(s_values[:, :, i]) for i in range(s_values.shape[2])
+            ]
+            self.classes = self.model.model_like.classes_
+        else:
+            raise RuntimeError(
+                f"Shap vales have unsuported format. Detected shape {s_values.shape}"
+            )
         return self
 
     def _get_overall_shap_contributions(self) -> DataFrame:
@@ -153,20 +168,8 @@ class ShapExplainer(Evaluator):
         DataFrame
             Summary of the Shapley values across the full dataset.
         """
-        classes = [None]
-        s_values = self.shap_values.values
 
-        if len(s_values.shape) == 2:
-            values_df = [DataFrame(s_values)]
-        elif len(s_values.shape) == 3:
-            values_df = [DataFrame(s_values[:, :, i]) for i in range(s_values.shape[2])]
-            classes = self.model.model_like.classes_
-        else:
-            raise RuntimeError(
-                f"Shap vales have unsuported format. Detected shape {s_values.shape}"
-            )
-
-        res = [self._summarize_shap_values(frame) for frame in values_df]
+        res = [self._summarize_shap_values(frame) for frame in self.values_df]
         containers = []
         for class_label, _res in enumerate(res):
             containers.append(
@@ -174,7 +177,7 @@ class ShapExplainer(Evaluator):
                     _res,
                     **self.get_container_info(
                         labels={
-                            "class_label": classes[class_label],
+                            "class_label": self.classes[class_label],
                             "feature_names": _res.index.to_list(),
                         }
                     ),
@@ -221,13 +224,11 @@ class ShapExplainer(Evaluator):
         """
         all_sample_shaps = []
         for ind in self.samples_ind:
-            all_sample_shaps.append(
-                {
-                    **self._get_single_sample_values(self.shap_values[ind]),
-                    **{"sample_pos": ind},
-                }
-            )
-        res = DataFrame(all_sample_shaps)
+            sample_results = self._get_single_sample_values(self.shap_values[ind])
+            sample_results = sample_results.assign(sample_pos=ind)
+            all_sample_shaps.append(sample_results)
+
+        res = concat(all_sample_shaps)
         res.name = "Shap values for specific samples"
         return res
 
@@ -254,8 +255,7 @@ class ShapExplainer(Evaluator):
                 message = "The maximum amount of individual samples_ind allowed is 5."
                 raise ValidationError(message)
 
-    @staticmethod
-    def _get_single_sample_values(sample_shap: Explanation) -> Dict:
+    def _get_single_sample_values(self, sample_shap: Explanation) -> Dict:
         """
         Returns shapley values for a specific sample in the dataset
 
@@ -275,7 +275,14 @@ class ShapExplainer(Evaluator):
             The model prediction for the sample is equal to: ref_value + sum(values)
         """
 
-        return {
-            "values": sample_shap.values,
-            "ref_value": sample_shap.base_values,
-        }
+        class_values = []
+        for label, cls in enumerate(self.classes):
+            class_values.append(
+                DataFrame({"values": sample_shap.values[:, label]}).assign(
+                    class_label=cls,
+                    ref_value=sample_shap.base_values[label],
+                    column_names=self.shap_values.feature_names,
+                )
+            )
+
+        return concat(class_values)

--- a/credoai/evaluators/shap.py
+++ b/credoai/evaluators/shap.py
@@ -274,6 +274,13 @@ class ShapExplainer(Evaluator):
         """
 
         class_values = []
+
+        if len(self.classes) == 1:
+            return DataFrame({"values": sample_shap.values}).assign(
+                ref_value=sample_shap.base_values,
+                column_names=self.shap_values.feature_names,
+            )
+
         for label, cls in enumerate(self.classes):
             class_values.append(
                 DataFrame({"values": sample_shap.values[:, label]}).assign(
@@ -282,5 +289,4 @@ class ShapExplainer(Evaluator):
                     column_names=self.shap_values.feature_names,
                 )
             )
-
         return concat(class_values)

--- a/credoai/evaluators/shap.py
+++ b/credoai/evaluators/shap.py
@@ -161,6 +161,10 @@ class ShapExplainer(Evaluator):
         elif len(s_values.shape) == 3:
             values_df = [DataFrame(s_values[:, :, i]) for i in range(s_values.shape[2])]
             classes = self.model.model_like.classes_
+        else:
+            raise RuntimeError(
+                f"Shap vales have unsuported format. Detected shape {s_values.shape}"
+            )
 
         res = [self._summarize_shap_values(frame) for frame in values_df]
         containers = []
@@ -173,7 +177,7 @@ class ShapExplainer(Evaluator):
                             "class_label": classes[class_label],
                             "feature_names": _res.index.to_list(),
                         }
-                    )
+                    ),
                 )
             )
         return containers

--- a/credoai/evaluators/shap.py
+++ b/credoai/evaluators/shap.py
@@ -91,7 +91,7 @@ class ShapExplainer(Evaluator):
         self.background_samples = background_samples
         self.background_kmeans = background_kmeans
 
-    name = "Shap"
+    name = "ShapExplainer"
     required_artifacts = ["assessment_data", "model"]
 
     def _setup(self):
@@ -176,7 +176,7 @@ class ShapExplainer(Evaluator):
                 TableContainer(
                     _res,
                     **self.get_container_info(
-                        labels={
+                        metadata={
                             "class_label": self.classes[class_label],
                             "feature_names": _res.index.to_list(),
                         }


### PR DESCRIPTION
## Fixing Shap behavior for multiclass model

Shap values output changes when the model prediction is multiclass.
Evaluator was changed to account for that. For multiclass:

- Table output contains a class column that specifies the reference class for the shap values

## Re-alligned feature drift with Platform
- Changed name and labels structure to re-allign with platform


