### PR TITLE
DataProfiler evidence fix + version update

### DIFF
--- a/credoai/__init__.py
+++ b/credoai/__init__.py
@@ -2,4 +2,4 @@
 Primary interface for Credo AI Lens package
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/credoai/evidence/evidence.py
+++ b/credoai/evidence/evidence.py
@@ -157,7 +157,7 @@ class DataProfilerEvidence(Evidence):
 
     def __init__(self, data: dict, additional_labels: dict = None, **metadata):
         self._data = data
-        super().__init__("profiler", additional_labels, **metadata)
+        super().__init__("dataset_profiler", additional_labels, **metadata)
 
     @property
     def data(self):


### PR DESCRIPTION
## Fix evidence type to match platform

DataProfiler was using data `DataProfilerEvidence` with `type="profiler"` this doesn't match current platform.
--> Changed type to "dataset_profiler"