### PR TITLE
modify quantization of roc and pr curve interpolation helpers to ensure adequately dense interpolation

### DIFF
--- a/credoai/modules/credoai_metrics.py
+++ b/credoai/modules/credoai_metrics.py
@@ -233,8 +233,11 @@ def ks_statistic(y_true, y_pred) -> float:
     return ks_stat
 
 
-def interpolate_increasing_thresholds(lib_thresholds, *series, quantization=0.01):
+def interpolate_increasing_thresholds(lib_thresholds, *series):
     out = [list() for i in series]
+    quantization = 1 / (
+        len(lib_thresholds) * (max(lib_thresholds) - min(lib_thresholds))
+    )
     interpolated_thresholds = np.arange(
         min(lib_thresholds), max(lib_thresholds), quantization
     )
@@ -250,8 +253,11 @@ def interpolate_increasing_thresholds(lib_thresholds, *series, quantization=0.01
     return out + [interpolated_thresholds]
 
 
-def interpolate_decreasing_thresholds(lib_thresholds, *series, quantization=-0.01):
+def interpolate_decreasing_thresholds(lib_thresholds, *series):
     out = [list() for i in series]
+    quantization = -1 / (
+        len(lib_thresholds) * (max(lib_thresholds) - min(lib_thresholds))
+    )
     interpolated_thresholds = np.arange(
         max(lib_thresholds), min(lib_thresholds), quantization
     )


### PR DESCRIPTION


## Change description

For some applications, ROC curve appears cut off when plotted. This is due to insufficiently granular interpolation of outputs of sklearn's `roc_curve` function.

Modified quantization level in interpolator helper functions to be set as a function of 1) number of thresholds returned by `roc_curve` function (or pr curve or det curve) and 2) difference between max and min threshold.

## Type of change
- [ X] Bug fix (fixes an issue)
