### PR TITLE
Docs/list metrics

### DIFF
--- a/credoai/evidence/evidence.py
+++ b/credoai/evidence/evidence.py
@@ -5,7 +5,6 @@ import json
 import pprint
 from abc import ABC, abstractproperty
 from datetime import datetime
-from symbol import parameters
 from typing import Tuple
 
 from credoai.utils import ValidationError

--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -34,7 +34,9 @@ class PipelineStep:
         self.metadata["evaluator"] = self.evaluator.name
 
     def check_match(self, metadata):
-        """Return true if metadata is a subset of pipeline step's metadata"""
+        """
+        Return true if metadata is a subset of pipeline step's metadata
+        """
         return check_subset(metadata, self.metadata)
 
 

--- a/credoai/modules/metric_utils.py
+++ b/credoai/modules/metric_utils.py
@@ -13,9 +13,6 @@ from sklearn.utils import resample
 
 
 def list_metrics(verbose=True):
-    """
-    Test docstring for documentation??
-    """
     metrics = defaultdict(set)
     for metric in ALL_METRICS:
         if metric.metric_category in MODEL_METRIC_CATEGORIES:

--- a/credoai/modules/metric_utils.py
+++ b/credoai/modules/metric_utils.py
@@ -13,6 +13,9 @@ from sklearn.utils import resample
 
 
 def list_metrics(verbose=True):
+    """
+    Test docstring for documentation??
+    """
     metrics = defaultdict(set)
     for metric in ALL_METRICS:
         if metric.metric_category in MODEL_METRIC_CATEGORIES:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,3 +4,5 @@
    :recursive:
 
    credoai
+
+automodule: credoai_lens

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,8 +28,6 @@ release = credoai.__version__
 autodoc_mock_imports = ["bs4", "requests"]
 exec_code_source_folders = [os.path.abspath("..")]
 
-print(exec_code_source_folders)
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ import furo
 
 sys.path.insert(0, os.path.abspath(".."))
 import credoai
+from credoai.modules.metric_utils import list_metrics
 
 # -- Project information -----------------------------------------------------
 
@@ -24,6 +25,10 @@ project = "Credo AI | Lens"
 copyright = "2021, Credo AI Development Team"
 author = "Credo AI Development Team"
 release = credoai.__version__
+autodoc_mock_imports = ["bs4", "requests"]
+exec_code_source_folders = [os.path.abspath("..")]
+
+print(exec_code_source_folders)
 
 # -- General configuration ---------------------------------------------------
 
@@ -42,6 +47,7 @@ extensions = [
     "sphinx_autodoc_typehints",  # needs to be AFTER napoleon
     "sphinx_rtd_theme",
     "nbsphinx",
+    "sphinx_exec_code",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -63,7 +69,7 @@ set_type_checking_flag = True
 nbsphinx_allow_errors = True  # Continue through Jupyter errors
 nbsphinx_execute = "never"  # do not execute jupyter notebooks
 
-autodoc_mock_imports = [
+autodoc_mock_imports += [
     "absl",
     "art",
     "art.attacks.evasion",

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -5,7 +5,7 @@ Lens supports many metrics out-of-the-box.
 Below are some of the metrics we support. For a comprehensive list, 
 the following can be run in your python environment:
 
-::
+.. exec_code::
 
    from credoai.modules.metric_utils import list_metrics
    list_metrics()
@@ -13,6 +13,8 @@ the following can be run in your python environment:
 
 Other metrics are easily incorporated by using the `Metric` class, which can accommodate 
 any assessment function.
+
+
 
 Metric list
 -----------

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -2,24 +2,16 @@ Metrics
 =======
 
 Lens supports many metrics out-of-the-box. 
-Below are some of the metrics we support. For a comprehensive list, 
-the following can be run in your python environment:
+The following gives a comprehensive list, which you can also generate in your python environment:
 
 .. exec_code::
 
    from credoai.modules.metric_utils import list_metrics
    list_metrics()
 
+Below we provide details for a selection of these supported metrics. 
 
-Other metrics are easily incorporated by using the `Metric` class, which can accommodate 
-any assessment function.
-
-.. exec_code::
-
-   from credoai.modules.metric_constants import BINARY_CLASSIFICATION_FUNCTIONS
-   for key, value in BINARY_CLASSIFICATION_FUNCTIONS.items():
-      print(key)
-      print(value.__doc__)
+Custom metrics are supported by using the `Metric` class, which can be used to wrap any assessment function.
 
 
 Metric list
@@ -525,4 +517,8 @@ Dimension: ``performance``
 
 ------------
 
-**Note**: all the metrics tagged with ``performance`` dimension would have ``fairness`` dimension too in the presence of sensitive features as it makes disaggregated parity assessment possible.
+**Note**: All the metrics above with the ``performance`` tag can be evaluated using 
+the `Performance evaluator <https://credoai-lens.readthedocs.io/en/latest/evaluators.html>`__.
+These can also be used to evaluate a model's fairness, using 
+the `ModelFairness <https://credoai-lens.readthedocs.io/en/latest/evaluators.html>`__ evaluator when a sensitive feature
+is present and specified in the dataset. This will disaggregate metrics by group and assess parity for each metric.

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -14,6 +14,12 @@ the following can be run in your python environment:
 Other metrics are easily incorporated by using the `Metric` class, which can accommodate 
 any assessment function.
 
+.. exec_code::
+
+   from credoai.modules.metric_constants import BINARY_CLASSIFICATION_FUNCTIONS
+   for key, value in BINARY_CLASSIFICATION_FUNCTIONS.items():
+      print(key)
+      print(value.__doc__)
 
 
 Metric list

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,3 +11,6 @@ sphinx-copybutton==0.5.0
 sphinx-gallery==0.10.1
 sphinx-rtd-theme==1.0.0
 sphinx-exec-code==0.8
+numpy==1.23.3
+scipy==1.9.1
+sklearn==1.1.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,3 +15,4 @@ numpy==1.23.3
 scipy==1.9.1
 scikit-learn==1.1.2
 pandas==1.4.4
+fairlearn==0.7.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,3 +14,4 @@ sphinx-exec-code==0.8
 numpy==1.23.3
 scipy==1.9.1
 scikit-learn==1.1.2
+pandas==1.4.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,3 +16,4 @@ scipy==1.9.1
 scikit-learn==1.1.2
 pandas==1.4.4
 fairlearn==0.7.0
+lifelines>=0.27.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ sphinx-autodoc-typehints==1.12.0
 sphinx-copybutton==0.5.0
 sphinx-gallery==0.10.1
 sphinx-rtd-theme==1.0.0
+sphinx-exec-code==0.8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,4 +13,4 @@ sphinx-rtd-theme==1.0.0
 sphinx-exec-code==0.8
 numpy==1.23.3
 scipy==1.9.1
-sklearn==1.1.2
+scikit-learn==1.1.2


### PR DESCRIPTION
## Change description

Modify https://credoai-lens.readthedocs.io/en/latest/metrics.html# to support call to `list_metrics` so all supported metrics can be displayed.

NOTE: I TESTED THIS "LOCALLY" IN A VSCODE RENDER OF THE HTML. I DO NOT KNOW HOW TO TEST ON READTHEDOCS WITHOUT MERGING TO DEVELOP BRANCH.

## Type of change
- [X ] New feature (adds functionality)