### PR TITLE
Modify get_model_info and update_functionality so that model frameworks are full string. Enables use of XGBoost within Credo Models

### DIFF
--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -1,6 +1,8 @@
 """Model artifact wrapping any classification model"""
 from .base_model import Model
 
+PREDICT_PROBA_FRAMEWORKS = ["sklearn", "xgboost"]
+
 
 class ClassificationModel(Model):
     """Class wrapper around classification model to be assessed
@@ -32,7 +34,7 @@ class ClassificationModel(Model):
 
     def _update_functionality(self):
         """Conditionally updates functionality based on framework"""
-        if "sklearn" in self.model_info["framework"]:
+        if self.model_info["framework"] in PREDICT_PROBA_FRAMEWORKS:
             func = getattr(self, "predict_proba", None)
             if func and len(self.model_like.classes_) == 2:
                 self.__dict__["predict_proba"] = lambda x: func(x)[:, 1]

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -32,7 +32,7 @@ class ClassificationModel(Model):
 
     def _update_functionality(self):
         """Conditionally updates functionality based on framework"""
-        if self.model_info["framework"] == "sklearn":
+        if "sklearn" in self.model_info["framework"]:
             func = getattr(self, "predict_proba", None)
             if func and len(self.model_like.classes_) == 2:
                 self.__dict__["predict_proba"] = lambda x: func(x)[:, 1]

--- a/credoai/utils/model_utils.py
+++ b/credoai/utils/model_utils.py
@@ -24,7 +24,7 @@ def get_generic_classifier():
 
 def get_model_info(model):
     try:
-        framework = model.__class__.__module__.split(".")[0]
+        framework = model.__class__.__module__
     except AttributeError:
         framework = None
     return {"framework": framework}

--- a/credoai/utils/model_utils.py
+++ b/credoai/utils/model_utils.py
@@ -24,7 +24,7 @@ def get_generic_classifier():
 
 def get_model_info(model):
     try:
-        framework = model.__class__.__module__
+        framework = model.__class__.__module__.split(".")[0]
     except AttributeError:
         framework = None
     return {"framework": framework}


### PR DESCRIPTION


## Change description
See https://github.com/credo-ai/credoai_lens/pull/185 

Fixes same issue but now enables XGBoostClassifier (which has a framework string of "xgboost.sklearn" and was not previously having its `predict_proba()` functionality updated when wrapped in a Credo `ClassificationModel`

Specifically: modify `get_model_info()` utility function to keep framework as full string (not split, not indexed). Modify `update_functionality()` in `ClassificationModel` class to check for `"sklearn"` in the `framework` variable rather than strict equality.

## Type of change
- [ X] Bug fix (fixes an issue)