### PR TITLE
238 shallow copy issue creating lens objects with the same pipeline object causes the latter object to overwrite the results from the former

### DIFF
--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -393,12 +393,12 @@ class Lens:
         for step in pipeline:
             if not isinstance(step, tuple):
                 step = (step,)
-            evaltr, meta = self._consume_pipeline_step(step)
+            evaltr, meta = self._consume_pipeline_step(deepcopy(step))
             if isclass(evaltr):
                 raise ValidationError(
                     f"Evaluator in step {step} needs to be instantiated"
                 )
-            self.add(deepcopy(evaltr), meta)
+            self.add(evaltr, meta)
         return self
 
     def _validate(self):

--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -398,7 +398,7 @@ class Lens:
                 raise ValidationError(
                     f"Evaluator in step {step} needs to be instantiated"
                 )
-            self.add(evaltr, meta)
+            self.add(deepcopy(evaltr), meta)
         return self
 
     def _validate(self):


### PR DESCRIPTION
## Change description

Deep copy pipeline steps for all evaluators added to Lens as part of pipeline list passed to the Lens constructor (rather than added individually through `add()`

## Type of change
- [ X] Bug fix (fixes an issue)

#238 