### PR TITLE
Add joblib support to Lens to enable running evaluators in parallel

### DIFF
--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -8,6 +8,7 @@ from inspect import isclass
 from typing import Dict, List, Optional, Tuple, Union
 
 from connect.governance import Governance
+from joblib import Parallel, delayed
 
 from credoai.artifacts import Data, Model
 from credoai.evaluators.evaluator import Evaluator
@@ -50,6 +51,7 @@ class Lens:
         training_data: Data = None,
         pipeline: Pipeline = None,
         governance: Governance = None,
+        n_jobs: int = 1,
     ) -> None:
         """
         Initializer for the Lens class.
@@ -73,6 +75,10 @@ class Lens:
             Lens and the Credo AI Platform. Specifically, evidence requirements taken from
             policy packs defined on the platform will configure Lens, and evidence created by
             Lens can be exported to the platform.
+        n_jobs : integer, optional
+            Number of evaluator jobs to run in parallel.
+            Uses joblib Parallel construct with multiprocessing backend.
+            Specifying n_jobs = -1 will use all available processors.
         """
         self.model = model
         self.assessment_data = assessment_data
@@ -85,6 +91,7 @@ class Lens:
             self.sens_feat_names = list(self.assessment_data.sensitive_features)
         else:
             self.sens_feat_names = []
+        self.n_jobs = n_jobs
         self._add_governance(governance)
         self._generate_pipeline(pipeline)
         # Can  pass pipeline directly
@@ -172,9 +179,16 @@ class Lens:
         """
         if self.pipeline == []:
             raise RuntimeError("No evaluators were added to the pipeline.")
-        for step in self.pipeline:
-            self.logger.info(f"Running evaluation for step: {step}")
-            step.evaluator.evaluate()
+
+        # Run evaluators in parallel. Shared object (self.pipeline) necessitates writing
+        # results to intermediate object evaluator_results
+        evaluator_results = Parallel(n_jobs=self.n_jobs, verbose=100)(
+            delayed(step.evaluator.evaluate)() for step in self.pipeline
+        )
+
+        # Write intermediate evaluator results back into self.pipeline for later processing
+        for idx, evaluator in enumerate(evaluator_results):
+            self.pipeline[idx].evaluator = evaluator
         return self
 
     def send_to_governance(self, overwrite_governance=False):


### PR DESCRIPTION
## Change description

Modify Lens class to support optional use of joblib.

Lens constructor now takes as optional input an `n_jobs` parameter. Parameter is used in the `Lens.run()` function to parallelize running of evaluators.

Results returned by each evaluator's `evaluate` function are evaluators, rather than pipeline steps. Therefore, results must be stored in an intermediate list and then re-matched with metadata in `self.pipeline`

## Type of change
- [x] Bug fix (fixes an issue)
- [ X] New feature (adds functionality)
