### PR TITLE
Add functionality to check version of Lens on import

### DIFF
--- a/credoai/__init__.py
+++ b/credoai/__init__.py
@@ -2,4 +2,14 @@
 Primary interface for Credo AI Lens package
 """
 
-__version__ = "1.1.2"
+from importlib.metadata import version
+
+# get package version programatically from installed wheel
+# does not rely on update to __init__.py for each new release
+# __version__ = version("credoai-lens")
+__version__ = "1.0.0"
+
+
+from credoai.utils.version_check import validate_version
+
+validate_version()

--- a/credoai/__init__.py
+++ b/credoai/__init__.py
@@ -2,12 +2,7 @@
 Primary interface for Credo AI Lens package
 """
 
-from importlib.metadata import version
-
-# get package version programatically from installed wheel
-# does not rely on update to __init__.py for each new release
-# __version__ = version("credoai-lens")
-__version__ = "1.0.0"
+__version__ = "1.1.2"
 
 
 from credoai.utils.version_check import validate_version

--- a/credoai/utils/__init__.py
+++ b/credoai/utils/__init__.py
@@ -6,3 +6,4 @@ from .common import *
 from .dataset_utils import *
 from .logging import *
 from .model_utils import *
+from .version_check import *

--- a/credoai/utils/version_check.py
+++ b/credoai/utils/version_check.py
@@ -1,0 +1,23 @@
+import requests
+import credoai
+from credoai.utils import global_logger
+
+
+def validate_version():
+    current_version = credoai.__version__
+
+    package = "credoai-lens"  # replace with the package you want to check
+    response = requests.get(f"https://pypi.org/pypi/{package}/json")
+    latest_version = response.json()["info"]["version"]
+
+    on_latest = current_version == latest_version
+
+    if not on_latest:
+        global_logger.warning(
+            """
+            You are using credoai-lens version %s, however a newer version is available.
+            Lens is updated regularly with major improvements and bug fixes.
+            Please upgrade via the command: "python -m pip install --upgrade credoai-lens"
+            """,
+            current_version,
+        )


### PR DESCRIPTION
## Change description
Changes credoai-lens's version to be based on installed wheel, rather than hardcoded string.

Adds functionality to check latest version of package on PyPI. If installed version is not identical to latest version, Lens's logger will throw a warning instructing the user to update.

## Type of change
- [ ] Bug fix (fixes an issue)
- [X ] New feature (adds functionality)

