### PR TITLE
Tests/export json

### DIFF
--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -28,6 +28,8 @@ from credoai.lens import Lens
 
 from connect.governance import Governance
 
+import tempfile
+
 TEST_METRICS = [
     ["false_negative_rate"],
     ["average_precision_score"],
@@ -93,6 +95,10 @@ def test_model_fairness(
     assert lens.get_results()
     assert lens.get_evidence()
     assert lens.send_to_governance()
+    tfile = tempfile.NamedTemporaryFile(delete=False)
+    assert not gov._file_export(
+        tfile.name
+    )  # governance file IO returns None if successful
 
 
 def test_privacy(
@@ -110,6 +116,10 @@ def test_privacy(
     assert lens.get_results()
     assert lens.get_evidence()
     assert lens.send_to_governance()
+    tfile = tempfile.NamedTemporaryFile(delete=False)
+    assert not gov._file_export(
+        tfile.name
+    )  # governance file IO returns None if successful
 
 
 class TestDataFairness(Base_Evaluator_Test):
@@ -129,6 +139,12 @@ class TestDataFairness(Base_Evaluator_Test):
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
 
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
+
 
 class TestDataProfiler(Base_Evaluator_Test):
     evaluator = DataProfiler()
@@ -146,6 +162,12 @@ class TestDataProfiler(Base_Evaluator_Test):
 
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
+
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
 
 
 class TestModelEquity(Base_Evaluator_Test):
@@ -165,6 +187,12 @@ class TestModelEquity(Base_Evaluator_Test):
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
 
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
+
 
 class TestDataEquity(Base_Evaluator_Test):
     evaluator = DataEquity()
@@ -182,6 +210,12 @@ class TestDataEquity(Base_Evaluator_Test):
 
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
+
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
 
 
 class TestSecurity(Base_Evaluator_Test):
@@ -201,6 +235,12 @@ class TestSecurity(Base_Evaluator_Test):
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
 
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
+
 
 @pytest.mark.parametrize("metrics", TEST_METRICS, ids=TEST_METRICS_IDS)
 def test_performance(
@@ -219,6 +259,10 @@ def test_performance(
     assert lens.get_results()
     assert lens.get_evidence()
     assert lens.send_to_governance()
+    tfile = tempfile.NamedTemporaryFile(delete=False)
+    assert not gov._file_export(
+        tfile.name
+    )  # governance file IO returns None if successful
 
 
 class TestThresholdPerformance(Base_Evaluator_Test):
@@ -238,6 +282,12 @@ class TestThresholdPerformance(Base_Evaluator_Test):
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
 
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
+
 
 class TestThresholdPerformanceMultiple(Base_Evaluator_Test):
     evaluator = Performance(["roc_curve", "precision_recall_curve"])
@@ -255,6 +305,12 @@ class TestThresholdPerformanceMultiple(Base_Evaluator_Test):
 
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
+
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
 
 
 class TestFeatureDrift(Base_Evaluator_Test):
@@ -274,6 +330,12 @@ class TestFeatureDrift(Base_Evaluator_Test):
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
 
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
+
 
 class TestDeepchecks(Base_Evaluator_Test):
     evaluator = Deepchecks()
@@ -291,6 +353,12 @@ class TestDeepchecks(Base_Evaluator_Test):
 
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
+
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
 
 
 class TestRankingFairnes:
@@ -339,6 +407,12 @@ class TestRankingFairnes:
 
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
+
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
 
     def test_results(self):
         results = self.pipeline.get_results()[0]["results"][0].round(2)
@@ -477,6 +551,12 @@ class TestIdentityVerification:
     def test_to_gov(self):
         assert self.pipeline.send_to_governance()
 
+    def test_gov_export(self):
+        tfile = tempfile.NamedTemporaryFile(delete=False)
+        assert not self.pipeline.gov._file_export(
+            tfile.name
+        )  # governance file IO returns None if successful
+
     def test_results_performance(self):
         results_perf = self.pipeline.get_results()[0]["results"][0].round(2)
         results_perf = results_perf.reset_index(drop=True)
@@ -513,6 +593,10 @@ def test_bulk_pipeline_run(
     assert my_pipeline.get_results()
     assert my_pipeline.get_evidence()
     assert my_pipeline.send_to_governance()
+    tfile = tempfile.NamedTemporaryFile(delete=False)
+    assert not gov._file_export(
+        tfile.name
+    )  # governance file IO returns None if successful
 
 
 @pytest.mark.xfail(raises=RuntimeError)

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -87,7 +87,7 @@ def test_model_fairness(
         model=classification_model,
         assessment_data=classification_assessment_data,
         training_data=classification_train_data,
-        governance=gov
+        governance=gov,
     )
     evaluator = ModelFairness(metrics)
     lens.add(evaluator)
@@ -106,7 +106,7 @@ def test_privacy(
         model=credit_classification_model,
         assessment_data=credit_assessment_data,
         training_data=credit_training_data,
-        governance=gov
+        governance=gov,
     )
     lens.add(Privacy(attack_feature="MARRIAGE"))
     lens.run()
@@ -215,7 +215,7 @@ def test_performance(
         model=credit_classification_model,
         assessment_data=credit_assessment_data,
         training_data=credit_training_data,
-        governance=gov
+        governance=gov,
     )
     evaluator = Performance(metrics)
     lens.add(evaluator)
@@ -514,7 +514,7 @@ def test_bulk_pipeline_run(
         assessment_data=classification_assessment_data,
         training_data=classification_train_data,
         pipeline=pipe_structure,
-        governance=gov
+        governance=gov,
     )
     my_pipeline.run()
     assert my_pipeline.get_results()

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -52,7 +52,6 @@ def init_lens(
     request,
 ):
     gov = Governance()
-    gov.register()
     my_pipeline = Lens(
         model=classification_model,
         assessment_data=classification_assessment_data,
@@ -82,7 +81,6 @@ def test_model_fairness(
     metrics,
 ):
     gov = Governance()
-    gov.register()
     lens = Lens(
         model=classification_model,
         assessment_data=classification_assessment_data,
@@ -101,7 +99,6 @@ def test_privacy(
     credit_classification_model, credit_assessment_data, credit_training_data
 ):
     gov = Governance()
-    gov.register()
     lens = Lens(
         model=credit_classification_model,
         assessment_data=credit_assessment_data,
@@ -210,7 +207,6 @@ def test_performance(
     credit_classification_model, credit_assessment_data, credit_training_data, metrics
 ):
     gov = Governance()
-    gov.register()
     lens = Lens(
         model=credit_classification_model,
         assessment_data=credit_assessment_data,
@@ -328,7 +324,6 @@ class TestRankingFairnes:
         }
     )
     gov = Governance()
-    gov.register()
     pipeline = Lens(assessment_data=data, governance=gov)
 
     def test_add(self):
@@ -462,7 +457,6 @@ class TestIdentityVerification:
     credo_model = ComparisonModel(name="face-compare", model_like=face_compare)
 
     gov = Governance()
-    gov.register()
     pipeline = Lens(model=credo_model, assessment_data=credo_data, governance=gov)
 
     def test_add(self):
@@ -508,7 +502,6 @@ def test_bulk_pipeline_run(
         DataFairness(),
     ]
     gov = Governance()
-    gov.register()
     my_pipeline = Lens(
         model=classification_model,
         assessment_data=classification_assessment_data,


### PR DESCRIPTION
## Change description

Add calls to `governance.export()` to each test via internal method `governance._file_export()`. Need to use this helper function since tests do not register governance to a Platform use case/policy pack/api url.

Helps ensure that JSON writing is successful (catches recent bugs related to datetimes and [NaNs](https://github.com/credo-ai/credoai_connect/pull/3) in JSONs).

NOTE: This is a branch off of https://github.com/credo-ai/credoai_lens/pull/256. I created it as a separate branch/PR since it's a separate feature, potentially with it's own discussion of pros/cons.

NOTE 2: This currently fails! That is because it is catching a JSON bug in connect that has not yet been merged. See https://github.com/credo-ai/credoai_connect/pull/3

## Type of change
- [x] New feature (adds functionality)