### PR TITLE
Governance set_artifacts expects names, not objects

### DIFF
--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -346,7 +346,10 @@ class Lens:
         self.gov = governance
         if self.model:
             self.gov.set_artifacts(
-                self.model, self.model.tags, self.training_data, self.assessment_data
+                self.model.name,
+                self.model.tags,
+                self.training_data.name,
+                self.assessment_data.name,
             )
 
     def _cycle_add_through_ds_feat(

--- a/credoai/lens/lens.py
+++ b/credoai/lens/lens.py
@@ -344,13 +344,15 @@ class Lens:
         if governance is None:
             return
         self.gov = governance
+        artifact_args = {}
+        if self.training_data:
+            artifact_args["training_dataset"] = self.training_data.name
+        if self.assessment_data:
+            artifact_args["assessment_dataset"] = self.assessment_data.name
         if self.model:
-            self.gov.set_artifacts(
-                self.model.name,
-                self.model.tags,
-                self.training_data.name,
-                self.assessment_data.name,
-            )
+            artifact_args["model"] = self.model.name
+            artifact_args["model_tags"] = self.model.tags
+            self.gov.set_artifacts(**artifact_args)
 
     def _cycle_add_through_ds_feat(
         self,


### PR DESCRIPTION
#263 fix was still causing issues. 

Governance `set_artifacts()` expects strings, not model or data objects: https://github.com/credo-ai/credoai_connect/blob/develop/connect/governance/governance.py#L278

Evidence was showing up in Platform as an object rather than a name
<img width="826" alt="image" src="https://user-images.githubusercontent.com/114082449/204701657-2d663932-f040-4299-b465-dfd0676f7b0d.png">

Items 2 and 3 in the screenshot are same evidence. First is w/object passed to `set_artifacts()`, second with name passed (i.e. with the changes in this PR applied).