### PR TITLE
reformated confusion matrix

### DIFF
--- a/credoai/evaluators/performance.py
+++ b/credoai/evaluators/performance.py
@@ -292,7 +292,9 @@ def create_confusion_matrix(y_true, y_pred):
     labels = y_true.astype("category").cat.categories
     confusion = confusion_matrix(y_true, y_pred, normalize="true", labels=labels)
     confusion_df = pd.DataFrame(confusion, index=labels.copy(), columns=labels)
-    confusion_df.index.name = "True"
-    confusion_df.columns.name = "Predicted"
+    confusion_df.index.name = "true_label"
+    confusion_df = confusion_df.reset_index().melt(
+        id_vars=["true_label"], var_name="predicted_label"
+    )
     confusion_df.name = "Confusion Matrix"
     return confusion_df


### PR DESCRIPTION
## Describe your changes
Converts the confusion matrix table from a square table (with predicted labels as columns and true labels as rows) to a long format looking like this:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/85892367/205793598-0947d359-cdb8-476c-9bd9-1606f7de88f5.png">


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [x] I have thought expansively about edge cases and written tests for them
