### PR TITLE
Adds support for passing config and assessment plan URL for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - test/integration_test
     paths-ignore:
       - '**.md'
       - '**.rst'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Run tests
+        env:
+          CREDOAI_LENS_CONFIG_JSON_B64: ${{ secrets.CREDOAI_LENS_CONFIG_JSON_B64 }}
+          CREDOAI_LENS_PLAN_URL: ${{ secrets.CREDOAI_LENS_PLAN_URL }}
         run: |
           scripts/test.sh 
       - name: my-artifact

--- a/credoai/lens/pipeline_creator.py
+++ b/credoai/lens/pipeline_creator.py
@@ -11,6 +11,7 @@ from connect.evidence import EvidenceRequirement
 from connect.governance import Governance
 from credoai.evaluators import *
 from credoai.evaluators.utils import name2evaluator
+from credoai.utils.common import remove_suffix
 
 
 class PipelineCreator:
@@ -58,7 +59,7 @@ def extract_metrics(labels):
     """Extract metrics from a single evidence requirement"""
     metrics = set()
     if "metric_type" in labels:
-        metrics.add(labels["metric_type"].removesuffix("_parity"))
+        metrics.add(remove_suffix(labels["metric_type"], "_parity"))
     elif "metric_types" in labels:
         metrics = metrics.union(labels["metric_types"])
     return metrics

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 import pickle
+import os
+import base64
+import json
 
 from pytest import fixture
 from sklearn.ensemble import RandomForestClassifier
@@ -17,6 +20,7 @@ from credoai.artifacts.model.comparison_model import DummyComparisonModel
 from credoai.lens import Lens
 
 from connect.governance import Governance
+from connect.governance.credo_api_client import CredoApiConfig
 
 ################################################
 ############ Lens init #########################
@@ -402,11 +406,17 @@ def frozen_validation_data():
 
 @fixture(scope="session")
 def config_path_in():
-    return  # TODO!!! FILL IN WITH GITHUB SECRET FOR CONFIG FILE (API TOKEN)
-    # return ""
+    return os.getenv('CREDOAI_LENS_CONFIG_PATH', None)
+
+
+@fixture(scope="session")
+def api_config_in():
+    b64_config = os.getenv('CREDOAI_LENS_CONFIG_JSON_B64', None)
+    if b64_config:
+        return CredoApiConfig(**json.loads(base64.b64decode(b64_config)))
+    return None
 
 
 @fixture(scope="session")
 def assessment_plan_url_in():
-    return  # TODO!!! FILL IN WITH GITHUB SECRET FOR ASSESSMENT PLAN (API LINK)
-    # return ""
+    return os.getenv('CREDOAI_LENS_PLAN_URL', None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -406,12 +406,12 @@ def frozen_validation_data():
 
 @fixture(scope="session")
 def config_path_in():
-    return os.getenv('CREDOAI_LENS_CONFIG_PATH', None)
+    return os.getenv("CREDOAI_LENS_CONFIG_PATH", None)
 
 
 @fixture(scope="session")
 def api_config_in():
-    b64_config = os.getenv('CREDOAI_LENS_CONFIG_JSON_B64', None)
+    b64_config = os.getenv("CREDOAI_LENS_CONFIG_JSON_B64", None)
     if b64_config:
         return CredoApiConfig(**json.loads(base64.b64decode(b64_config)))
     return None
@@ -419,4 +419,4 @@ def api_config_in():
 
 @fixture(scope="session")
 def assessment_plan_url_in():
-    return os.getenv('CREDOAI_LENS_PLAN_URL', None)
+    return os.getenv("CREDOAI_LENS_PLAN_URL", None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 from connect.governance import Governance
+from connect.governance.credo_api_client import CredoApiClient
 from credoai.lens import Lens
 from credoai.artifacts import ClassificationModel, TabularData
 from credoai.datasets import fetch_credit_model
@@ -6,9 +7,12 @@ from credoai.datasets import fetch_credit_model
 import tempfile
 
 
-def test_integration(config_path_in, assessment_plan_url_in):
+def test_integration(api_config_in, config_path_in, assessment_plan_url_in):
     # Retrieve Policy Pack Assessment Plan
-    gov = Governance(config_path=config_path_in)
+    if api_config_in:
+        gov = Governance(credo_api_client=CredoApiClient(config=api_config_in))
+    else:
+        gov = Governance(config_path=config_path_in)
 
     gov.register(assessment_plan_url=assessment_plan_url_in)
 


### PR DESCRIPTION
## Describe your changes

Enabled these environment variables for use in CI jobs.

`CREDOAI_LENS_CONFIG_JSON_B64` - Base64 encoded json

Example:
```
export CREDOAI_LENS_CONFIG_JSON_B64=$(cat <<EOF
{
  "api_key": "secret",
  "tenant": "credoai",
  "api_server": "https://api.credo.ai"
}
EOF
)
```

`CREDOAI_LENS_PLAN_URL` - regular string

## Issue ticket number and link

## Known outstanding issues that are not fully accounted for

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [ ] I have thought expansively about edge cases and written tests for them
