### PR TITLE
fix(): restore env variables that were removed during the cleanup

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -47,6 +47,9 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Run tests
+        env:
+          CREDOAI_LENS_CONFIG_JSON_B64: ${{ env.CREDOAI_LENS_CONFIG_JSON_B64 }}
+          CREDOAI_LENS_PLAN_URL: ${{ env.CREDOAI_LENS_PLAN_URL }}
         run: |
           rm -rf test-reports/
           scripts/test-reports.sh


### PR DESCRIPTION
## Describe your changes

The env variables that are needed to run the integration test were dropped during some file shuffling.  This should fix things.

## Issue ticket number and link

## Known outstanding issues that are not fully accounted for

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [ ] I have thought expansively about edge cases and written tests for them
