### PR TITLE
Fixing validation for Dummy models which don't specify a prediction function

### DIFF
--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -167,15 +167,19 @@ class DummyClassifier:
             self.predict_output = check_array(
                 predict_output, ensure_2d=False, allow_nd=True
             )
+            self.__dict__["predict"] = lambda x=None: self.predict_output
+
         if predict_proba_output is not None:
             self.predict_proba_output = check_array(
                 predict_proba_output, ensure_2d=False, allow_nd=True
             )
+            self.__dict__["predict_proba"] = lambda x=None: self.predict_proba_output
+
         self.name = name
         self.tags = tags
 
-    def predict(self, X=None):
-        return self.predict_output
+    # def predict(self, X=None):
+    #     return self.predict_output
 
-    def predict_proba(self, X=None):
-        return self.predict_proba_output
+    # def predict_proba(self, X=None):
+    #     return self.predict_proba_output

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -163,23 +163,17 @@ class DummyClassifier:
         tags=None,
     ):
         self.model_like = model_like
-        if predict_output is not None:
-            self.predict_output = check_array(
-                predict_output, ensure_2d=False, allow_nd=True
-            )
-            self.__dict__["predict"] = lambda x=None: self.predict_output
-
-        if predict_proba_output is not None:
-            self.predict_proba_output = check_array(
-                predict_proba_output, ensure_2d=False, allow_nd=True
-            )
-            self.__dict__["predict_proba"] = lambda x=None: self.predict_proba_output
-
+        self._build_functionality("predict", predict_output)
+        self._build_functionality("predict_proba", predict_proba_output)
         self.name = name
         self.tags = tags
 
-    # def predict(self, X=None):
-    #     return self.predict_output
+    def _wrap_array(self, array):
+        return lambda X=None: array
+        # Keeping X as an optional argument to maintain potential backward compatibility
+        # Some uses of DummyClassifier may use predict() with no argument
 
-    # def predict_proba(self, X=None):
-    #     return self.predict_proba_output
+    def _build_functionality(self, function_name, array):
+        if array is not None:
+            array = check_array(array, ensure_2d=False, allow_nd=True)
+            self.__dict__[function_name] = self._wrap_array(array)

--- a/credoai/lens/lens_validation.py
+++ b/credoai/lens/lens_validation.py
@@ -36,68 +36,54 @@ def check_model_data_consistency(model, data):
     # check predict
     # Keras always outputs numpy types (not Tensor or something else)
     if "predict" in model.__dict__.keys() and data.y is not None and data.X is not None:
-        if isinstance(model.model_like, (DummyClassifier, DummyRegression)):
-            preds = model.predict()
-            if preds.shape != data.y.shape:
-                raise ValidationError(
-                    "Dummy model output shape does not match provided ground truth output shape."
-                )
-        else:
-            try:
-                mini_pred, batch_size = check_prediction_model_output(
-                    model.predict, data
-                )
-                if not mini_pred.size:
-                    # results for all presently supported models are ndarray results
-                    raise Exception("Empty return results from predict function.")
+        try:
+            mini_pred, batch_size = check_prediction_model_output(model.predict, data)
+            if not mini_pred.size:
+                # results for all presently supported models are ndarray results
+                raise Exception("Empty return results from predict function.")
+            if len(mini_pred.shape) > 1:
+                # check that output size per sample matches up
                 if isinstance(data.y, np.ndarray) and (
-                    mini_pred.shape != data.y[:batch_size].shape
+                    mini_pred.shape[1:] != data.y.shape[1:]
                 ):
                     raise Exception("Predictions have mismatched shape from provided y")
-                if isinstance(data.y, pd.Series) and (
-                    mini_pred.shape != data.y.head(batch_size).shape
+                elif isinstance(data.y, pd.Series) and (
+                    mini_pred.shape[1:] != data.y.head(batch_size).shape[1:]
                 ):
                     raise Exception("Predictions have mismatched shape from provided y")
-            except Exception as e:
-                raise ValidationError(
-                    "Lens.model predictions do not match expected form implied by provided labels y.",
-                    e,
-                )
+        except Exception as e:
+            raise ValidationError(
+                "Lens.model predictions do not match expected form implied by provided labels y.",
+                e,
+            )
 
     if (
         "predict_proba" in model.__dict__.keys()
         and data.y is not None
         and data.X is not None
     ):
-        if isinstance(model.model_like, (DummyClassifier)):
-            preds = model.predict()
-            if preds.shape != data.y.shape:
-                raise ValidationError(
-                    "Dummy model output shape does not match provided ground truth output shape."
-                )
-        else:
-            try:
-                mini_pred, batch_size = check_prediction_model_output(
-                    model.predict_proba, data
-                )
-                if not mini_pred.size:
-                    # results for all presently supported models are ndarray results
-                    raise Exception("Empty return results from predict_proba function.")
-                if len(mini_pred.shape) > 1 and mini_pred.shape[1] > 1:
-                    if np.sum(mini_pred[0]) != 1:
-                        raise Exception(
-                            "`predict_proba` outputs invalid. Per-sample outputs should sum to 1."
-                        )
-                else:
-                    if mini_pred[0] >= 1:
-                        raise Exception(
-                            "`predict_proba` outputs invalid. Binary outputs should be <= 1."
-                        )
-            except Exception as e:
-                raise ValidationError(
-                    "Lens.model outputs do not match expected form implied by provided labels y.",
-                    e,
-                )
+        try:
+            mini_pred, batch_size = check_prediction_model_output(
+                model.predict_proba, data
+            )
+            if not mini_pred.size:
+                # results for all presently supported models are ndarray results
+                raise Exception("Empty return results from predict_proba function.")
+            if len(mini_pred.shape) > 1 and mini_pred.shape[1] > 1:
+                if np.sum(mini_pred[0]) != 1:
+                    raise Exception(
+                        "`predict_proba` outputs invalid. Per-sample outputs should sum to 1."
+                    )
+            else:
+                if mini_pred[0] >= 1:
+                    raise Exception(
+                        "`predict_proba` outputs invalid. Binary outputs should be <= 1."
+                    )
+        except Exception as e:
+            raise ValidationError(
+                "Lens.model outputs do not match expected form implied by provided labels y.",
+                e,
+            )
 
     if "compare" in model.__dict__.keys() and data.pairs is not None:
         try:


### PR DESCRIPTION
## Describe your changes
For DummyClassifier: change prediction functions to be lambdas so that the functions don't refer to attributes that don't exist if the user has not provided one of predict/predict_proba

For DummyClassifier & DummyRegressor: change validation to compare ALL outputs of predict/predict proba to y. Other models jsut predict on a sample for latency reasons...Better to check full output for dummys

## Issue ticket number and link
https://credoai.slack.com/archives/C04612H3P7T/p1673996354009329

## Known outstanding issues that are not fully accounted for

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [ ] I have thought expansively about edge cases and written tests for them
