### PR TITLE
Fix/model validation

### DIFF
--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -43,6 +43,15 @@ class ClassificationModel(Model):
             If the final layer is sigmoid, this wrapper assumes the return value is an (n_samples, 1)
             column vector with per-sample probabilities. The wrapper rounds (.5 as default threshold)
             values where necessary to obtain discrete labels.
+
+            For custom model_like objects, users may optionally specify a `frameworks_like` attribute
+            of type list. frameworks_like serves as a flag to enable expected functionality to carry over
+            from an external framework to Lens. Presently frameworks_like = ["sklearn"] is supported and
+            serves as a flag to notify Lens that model_like respects sklearn's predict and (if appropriate)
+            predict_proba API. Future functionality: 'tensorflow' and 'pytorch' will also be supported, as
+            well as combinations: e.g. frameworks_like = ['sklearn', 'pytorch'] signals to Lens that
+            model_like supports both a `forward` function and the `predict` and (where appropriate) `predict_proba`.
+
     tags : optional
         Additional metadata to add to model
         E.g., {'model_type': 'binary_classification'}
@@ -75,6 +84,8 @@ class ClassificationModel(Model):
         """Conditionally updates functionality based on framework"""
         # This needs to remain a big if-statement for now if we're going to keep
         # all classifiers in one class since we're making direct assignments to the class object
+        framework_like = getattr(self.model_like, frameworks_like, None)
+
         if self.model_info["framework"] in SKLEARN_LIKE_FRAMEWORKS:
             func = getattr(self, "predict_proba", None)
             if len(self.model_like.classes_) == 2:
@@ -134,6 +145,18 @@ class ClassificationModel(Model):
             # is binary or multiclass
 
             # Predict and Predict_Proba should already be specified
+
+        if framework_like:
+            if "sklearn" in framework_like:
+                func = getattr(self, "predict_proba", None)
+                if len(self.model_like.classes_) == 2:
+                    self.type = "BINARY_CLASSIFICATION"
+                    # if binary, replace probability array with one-dimensional vector
+                    if func:
+                        self.__dict__["predict_proba"] = lambda x: func(x)[:, 1]
+                else:
+                    self.type = "MULTICLASS_CLASSIFICATION"
+            # Future: pytorch and tensorflow support
 
 
 class DummyClassifier:

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -84,7 +84,7 @@ class ClassificationModel(Model):
         """Conditionally updates functionality based on framework"""
         # This needs to remain a big if-statement for now if we're going to keep
         # all classifiers in one class since we're making direct assignments to the class object
-        framework_like = getattr(self.model_like, frameworks_like, None)
+        framework_like = getattr(self.model_like, "frameworks_like", None)
 
         if self.model_info["framework"] in SKLEARN_LIKE_FRAMEWORKS:
             func = getattr(self, "predict_proba", None)

--- a/credoai/lens/lens_validation.py
+++ b/credoai/lens/lens_validation.py
@@ -103,7 +103,7 @@ def check_model_data_consistency(model, data):
             )
 
 
-def check_prediction_model_output(fn, data, batch: int = 1):
+def check_prediction_model_output(fn, data, batch_in: int = 1):
     """
     Helper function for prediction-type models. For use with `check_model_data_consistency`.
 
@@ -122,16 +122,16 @@ def check_prediction_model_output(fn, data, batch: int = 1):
         since this could be large and computationally expensive.
     """
     mini_pred = None
-    batch_size = batch
+    batch_out = batch_in
     if isinstance(data.X, np.ndarray):
         mini_pred = fn(np.reshape(data.X[0], (1, -1)))
     elif isinstance(data.X, (pd.DataFrame, pd.Series)):
-        mini_pred = fn(data.X.head(batch))
+        mini_pred = fn(data.X.head(batch_in))
     elif isinstance(data.X, tf.Tensor):
         mini_pred = fn(data.X)
     elif isinstance(data.X, tf.data.Dataset) or inspect.isgeneratorfunction(data.X):
         one_batch = next(iter(data.X))
-        batch_size = len(one_batch)
+        batch_out = len(one_batch)
         if len(one_batch) >= 2:
             # batch is tuple
             # includes y and possibly weights; X is first
@@ -141,16 +141,16 @@ def check_prediction_model_output(fn, data, batch: int = 1):
             mini_pred = fn(one_batch)
     elif isinstance(data.X, tf.keras.utils.Sequence):
         mini_pred = fn(data.X.__getitem__(0))
-        batch_size = len(mini_pred)
+        batch_out = len(mini_pred)
     else:
         message = "Input X is of unsupported type. Behavior is undefined. Proceed with caution"
         global_logger.warning(message)
         mini_pred = fn(data.X[0])
 
-    return np.array(mini_pred), batch_size
+    return np.array(mini_pred), batch_out
 
 
-def check_comparison_model_output(fn, data, batch=1):
+def check_comparison_model_output(fn, data, batch_in=1):
     """
     Helper function for comparison-type models. For use with `check_model_data_consistency`.
 
@@ -168,13 +168,13 @@ def check_comparison_model_output(fn, data, batch=1):
         object since this could be large and computationally expensive.
     """
     comps = None
-    batch_size = batch
+    batch_out = batch_in
     if isinstance(data.pairs, pd.DataFrame):
         # should always pass for ComparisonData, based on checks in that wrapper. Nevertheless...
-        comps = fn(data.pairs.head(batch_size))
+        comps = fn(data.pairs.head(batch_in))
     else:
         message = "Input pairs are of unsupported type. Behavior is undefined. Proceed with caution"
         global_logger.warning(message)
-        comps = fn(data.pairs[:batch_size])
+        comps = fn(data.pairs[:batch_in])
 
-    return comps, batch_size
+    return comps, batch_out

--- a/credoai/lens/lens_validation.py
+++ b/credoai/lens/lens_validation.py
@@ -125,8 +125,8 @@ def check_prediction_model_output(fn, data, batch: int = 1):
     batch_size = batch
     if isinstance(data.X, np.ndarray):
         mini_pred = fn(np.reshape(data.X[0], (1, -1)))
-    elif isinstance(data.X, pd.DataFrame):
-        mini_pred = fn(data.X.head(1))
+    elif isinstance(data.X, (pd.DataFrame, pd.Series)):
+        mini_pred = fn(data.X.head(batch))
     elif isinstance(data.X, tf.Tensor):
         mini_pred = fn(data.X)
     elif isinstance(data.X, tf.data.Dataset) or inspect.isgeneratorfunction(data.X):

--- a/credoai/lens/lens_validation.py
+++ b/credoai/lens/lens_validation.py
@@ -147,7 +147,7 @@ def check_prediction_model_output(fn, data, batch: int = 1):
         global_logger.warning(message)
         mini_pred = fn(data.X[0])
 
-    return mini_pred, batch_size
+    return np.array(mini_pred), batch_size
 
 
 def check_comparison_model_output(fn, data, batch=1):

--- a/credoai/utils/model_utils.py
+++ b/credoai/utils/model_utils.py
@@ -30,7 +30,7 @@ def get_model_info(model):
     try:
         framework = model.__class__.__module__.split(".")[0]
     except AttributeError:
-        framework = None
+        framework = getattr(model, "framework_like", None)
     try:
         name = model.__class__.__name__
     except AttributeError:

--- a/credoai/utils/model_utils.py
+++ b/credoai/utils/model_utils.py
@@ -28,9 +28,11 @@ def get_generic_classifier():
 def get_model_info(model):
     """Returns basic information about model info"""
     try:
-        framework = model.__class__.__module__.split(".")[0]
-    except AttributeError:
         framework = getattr(model, "framework_like", None)
+        if not framework:
+            framework = model.__class__.__module__.split(".")[0]
+    except AttributeError:
+        framework = None
     try:
         name = model.__class__.__name__
     except AttributeError:


### PR DESCRIPTION
## Describe your changes
Model validation: add support for pd.Series as a datatype for X
Predict_proba functionality: for custom (non-Dummy) classifiers, we're going to allow users to "signal" to Lens that we should treat their `predict` and `predict_proba` functions as being sklearn-like. If the user adds a `frameworks_like` attribute (a list) to their custom classifier and pass that classifier as the `model_like` argument to `ClassificationModel`, we will check the contents of `framework_like`. If `sklearn` is in the attribute, we will take steps similar to existing `framework` checking and functionality updating. Note that _multiple_ frameworks can be specified. For instance, a user might want to pass a pytorch model that supports both `forward()` (default pytorch behavior) and custom-implemented `predict` and `predict_proba` behavior a la sklearn. In this case, the user would set an attribute in their custom model `frameworks_like = ['sklearn', 'pytorch']`. Full pytorch support not yet implemented.

## Issue ticket number and link
Zoom discussion

## Known outstanding issues that are not fully accounted for
Full support of `frameworks_like` not yet implemented.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [ ] I have thought expansively about edge cases and written tests for them
