### PR TITLE
Quick fixes for bugs relating to validation of string-containing DFs and default value for empty y_prob

### DIFF
--- a/credoai/artifacts/data/base_data.py
+++ b/credoai/artifacts/data/base_data.py
@@ -235,7 +235,7 @@ class Data:
             if self.y is not None:
                 y = pd.DataFrame(self.y)
                 for outcome, outcome_col in y.iteritems():
-                    for group, value in outcome_col.groupby(col).std().iteritems():
+                    for group, value in outcome_col.groupby(col).nunique().iteritems():
                         if value == 0:
                             global_logger.warning(
                                 "%s\n%s",

--- a/credoai/artifacts/data/base_data.py
+++ b/credoai/artifacts/data/base_data.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Optional, Union
 
 import pandas as pd
+import numpy as np
 
 from credoai.utils import global_logger
 from credoai.utils.common import ValidationError, check_pandas
@@ -236,7 +237,7 @@ class Data:
                 y = pd.DataFrame(self.y)
                 for outcome, outcome_col in y.iteritems():
                     for group, value in outcome_col.groupby(col).nunique().iteritems():
-                        if value < 2:
+                        if not np.all(value):
                             global_logger.warning(
                                 "%s\n%s",
                                 f"Dataset Issue! Zero variance in the outcome ({outcome}) detected for {group} under sensitive feature {col_name}.",

--- a/credoai/artifacts/data/base_data.py
+++ b/credoai/artifacts/data/base_data.py
@@ -236,7 +236,7 @@ class Data:
                 y = pd.DataFrame(self.y)
                 for outcome, outcome_col in y.iteritems():
                     for group, value in outcome_col.groupby(col).nunique().iteritems():
-                        if value == 0:
+                        if value < 2:
                             global_logger.warning(
                                 "%s\n%s",
                                 f"Dataset Issue! Zero variance in the outcome ({outcome}) detected for {group} under sensitive feature {col_name}.",

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -210,7 +210,7 @@ class DummyClassifier:
             if isinstance(array, pd.Series):
                 if not len(array):
                     raise Exception("Provided series for y_pred or y_prob is empty")
-                if np.issubdtype(array, np.number) and np.isinf(array).any():
+                if array.dtype is np.number and np.isinf(array).any():
                     raise Exception(
                         "Provided series for y_pred or y_prob contains infinite values"
                     )

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -210,7 +210,7 @@ class DummyClassifier:
             if isinstance(array, pd.Series):
                 if not len(array):
                     raise Exception("Provided series for y_pred or y_prob is empty")
-                if array.isinf().any():
+                if np.issubdtype(array, np.number) and np.isinf(array).any():
                     raise Exception(
                         "Provided series for y_pred or y_prob contains infinite values"
                     )

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -4,6 +4,7 @@ from .base_model import Model
 from credoai.utils import global_logger
 
 import numpy as np
+import pandas as pd
 
 from sklearn.utils import check_array
 
@@ -206,5 +207,13 @@ class DummyClassifier:
 
     def _build_functionality(self, function_name, array):
         if array is not None:
-            array = check_array(array, ensure_2d=False, allow_nd=True)
+            if isinstance(array, pd.Series):
+                if not len(array):
+                    raise Exception("Provided series for y_pred or y_prob is empty")
+                if array.isinf().any():
+                    raise Exception(
+                        "Provided series for y_pred or y_prob contains infinite values"
+                    )
+            else:
+                array = check_array(array, ensure_2d=False, allow_nd=True)
             self.__dict__[function_name] = self._wrap_array(array)

--- a/credoai/evaluators/fairness.py
+++ b/credoai/evaluators/fairness.py
@@ -64,7 +64,7 @@ class ModelFairness(Evaluator):
         if hasattr(self.model, "predict_proba"):
             self.y_prob = self.model.predict_proba(self.data.X)
         else:
-            self.y_prob = (None,)
+            self.y_prob = None
         self.update_metrics(self.metrics)
 
     def evaluate(self):


### PR DESCRIPTION
## Describe your changes
Change default value for `y_prob` in fairness.py to `None` from tuple.

Change variance checking in tabular data with sensitive features to simply check to see that there is more than 1 value for each sensitive group for the outcome. Addresses issue with string-type outcomes (which have no std function)

## Issue ticket number and link
https://credo-ai.atlassian.net/browse/DSP-464
https://credo-ai.atlassian.net/browse/DSP-465

## Known outstanding issues that are not fully accounted for
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [ ] I have thought expansively about edge cases and written tests for them
