### PR TITLE
Dsp 467 update multi class definition and criteria in lens

### DIFF
--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -87,18 +87,20 @@ class ClassificationModel(Model):
 
         if self.model_info["framework"] in SKLEARN_LIKE_FRAMEWORKS:
             func = getattr(self, "predict_proba", None)
-            if all(self.model_like.classes_ == [0, 1]):
-                self.type = "BINARY_CLASSIFICATION"
-                # if binary, replace probability array with one-dimensional vector
-                if func:
-                    self.__dict__["predict_proba"] = lambda x: func(x)[:, 1]
-            else:
-                self.type = "MULTICLASS_CLASSIFICATION"
-                if len(self.model_like.classes_) == 2:
+            if len(self.model_like.classes_) == 2:
+                if all(self.model_like.classes_ == [0, 1]):
+                    self.type = "BINARY_CLASSIFICATION"
+                    # if binary, replace probability array with one-dimensional vector
+                    if func:
+                        self.__dict__["predict_proba"] = lambda x: func(x)[:, 1]
+                else:
+                    self.type = "MULTICLASS_CLASSIFICATION"
                     message = f"\nThe model was considered of type {self.type}.\n"
                     message += f"Classes detected: {list(self.model_like.classes_)}\n"
                     message += f"Expected for binary classification: [0, 1]"
                     global_logger.warning(message)
+            else:
+                self.type = "MULTICLASS_CLASSIFICATION"
 
         elif self.model_info["framework"] in MLP_FRAMEWORKS:
             # TODO change this to '__call__' when adding in general TF and PyTorch

--- a/credoai/artifacts/model/classification_model.py
+++ b/credoai/artifacts/model/classification_model.py
@@ -87,13 +87,18 @@ class ClassificationModel(Model):
 
         if self.model_info["framework"] in SKLEARN_LIKE_FRAMEWORKS:
             func = getattr(self, "predict_proba", None)
-            if len(self.model_like.classes_) == 2:
+            if all(self.model_like.classes_ == [0, 1]):
                 self.type = "BINARY_CLASSIFICATION"
                 # if binary, replace probability array with one-dimensional vector
                 if func:
                     self.__dict__["predict_proba"] = lambda x: func(x)[:, 1]
             else:
                 self.type = "MULTICLASS_CLASSIFICATION"
+                if len(self.model_like.classes_) == 2:
+                    message = f"\nThe model was considered of type {self.type}.\n"
+                    message += f"Classes detected: {list(self.model_like.classes_)}\n"
+                    message += f"Expected for binary classification: [0, 1]"
+                    global_logger.warning(message)
 
         elif self.model_info["framework"] in MLP_FRAMEWORKS:
             # TODO change this to '__call__' when adding in general TF and PyTorch


### PR DESCRIPTION
## Describe your changes

Changed the way model type is determined:
- if only 2 classes are present, in order for it to be considered binary classification, they must be in the form [0, 1]
Otherwise the model is considered multiclass and a warning message is issued.

## Issue ticket number and link

## Known outstanding issues that are not fully accounted for

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have built basic tests for new functionality (particularly new evaluators)
- [ ] If new libraries have been added, I have checked that [readthedocs](https://readthedocs.org/projects/credoai-lens/) API documentation is constructed correctly
- [ ] Will this be part of a major product update? If yes, please write one phrase about this update.

## Extra-mile Checklist
- [ ] I have thought expansively about edge cases and written tests for them
